### PR TITLE
CI/tooling for webhook-ai + new tests + README badge

### DIFF
--- a/.github/workflows/webhook-ai-ci.yml
+++ b/.github/workflows/webhook-ai-ci.yml
@@ -1,0 +1,56 @@
+name: Webhook AI CI
+
+on:
+  push:
+    branches: [ main, master, feature/**, fix/**, ci/** ]
+    paths:
+      - 'webhook-ai/**'
+      - '.github/workflows/webhook-ai-ci.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'webhook-ai/**'
+      - '.github/workflows/webhook-ai-ci.yml'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: test
+      MOCK_SUPABASE: 'true'
+      QUOTE_OFFLINE_FALLBACK: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: 'webhook-ai/package-lock.json'
+
+      - name: Install dependencies (webhook-ai)
+        run: npm ci
+        working-directory: webhook-ai
+
+      - name: Lint (webhook-ai)
+        run: npm run lint
+        working-directory: webhook-ai
+
+      - name: Build (webhook-ai)
+        run: npm run build
+        working-directory: webhook-ai
+
+      - name: Test (webhook-ai)
+        run: npm run test -- --coverage
+        working-directory: webhook-ai
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: webhook-ai-coverage
+          path: webhook-ai/coverage
+          if-no-files-found: ignore
+

--- a/.github/workflows/webhook-ai-smoke.yml
+++ b/.github/workflows/webhook-ai-smoke.yml
@@ -1,0 +1,42 @@
+name: Webhook AI Smoke
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'webhook-ai/scripts/smoke-*.mjs'
+      - '.github/workflows/webhook-ai-smoke.yml'
+
+jobs:
+  smoke:
+    name: Smoke (requires API_URL & BOT_TOKEN secrets)
+    runs-on: ubuntu-latest
+    env:
+      API_URL: ${{ secrets.API_URL }}
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+    steps:
+      - name: Check required secrets
+        if: ${{ env.API_URL == '' || env.BOT_TOKEN == '' }}
+        run: |
+          echo "Skipping smoke: missing API_URL or BOT_TOKEN secrets"
+          exit 0
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install root dependencies (for dotenv)
+        run: npm ci
+
+      - name: Smoke orçamento
+        run: node webhook-ai/scripts/smoke-orcamento.mjs
+
+      - name: Smoke agendamento
+        run: node webhook-ai/scripts/smoke-agendamento.mjs
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Fix Fogões - Sistema de Gestão de Assistência Técnica
 
+![Webhook AI CI](https://github.com/razzachan/fix-agendamento/actions/workflows/webhook-ai-ci.yml/badge.svg)
+
+
 🚀 **Deploy Automático Ativo** - Sistema configurado e funcionando!
 
 ## 🧪 TESTE DE DEPLOY AUTOMÁTICO

--- a/webhook-ai/.eslintrc.cjs
+++ b/webhook-ai/.eslintrc.cjs
@@ -1,0 +1,28 @@
+/* eslint-env node */
+module.exports = {
+  root: true,
+  env: { node: true, es2022: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  plugins: ['@typescript-eslint', 'import'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'prettier',
+  ],
+  settings: {
+    'import/resolver': {
+      node: { extensions: ['.js', '.ts'] },
+    },
+  },
+  rules: {
+    'no-console': 'off',
+    'import/no-unresolved': 'off',
+    'import/extensions': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+  },
+  ignorePatterns: ['dist/', 'node_modules/'],
+};
+

--- a/webhook-ai/.prettierrc
+++ b/webhook-ai/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 100,
+  "trailingComma": "es5"
+}
+

--- a/webhook-ai/eslint.config.mjs
+++ b/webhook-ai/eslint.config.mjs
@@ -1,0 +1,35 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import importPlugin from 'eslint-plugin-import';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.{ts,js}', 'test/**/*.ts'],
+    ignores: ['dist/**', 'node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    plugins: {
+      import: importPlugin,
+    },
+    rules: {
+      // Relax rules to fit current codebase and avoid churn; we can tighten incrementally
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/ban-ts-comment': 'off',
+      'no-empty': 'off',
+      'prefer-const': 'off',
+      'prefer-rest-params': 'off',
+      'no-useless-escape': 'off',
+      'no-control-regex': 'off',
+      'import/no-unresolved': 'off',
+      'import/extensions': 'off',
+      // Keep console logs for observability in this service
+      'no-console': 'off',
+    },
+  }
+);
+

--- a/webhook-ai/package-lock.json
+++ b/webhook-ai/package-lock.json
@@ -22,6 +22,12 @@
         "@types/express": "^4.17.21",
         "@types/node": "^20.14.9",
         "@types/supertest": "^2.0.16",
+        "@typescript-eslint/eslint-plugin": "^8.42.0",
+        "@typescript-eslint/parser": "^8.42.0",
+        "eslint": "^9.35.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-import": "^2.32.0",
+        "prettier": "^3.6.2",
         "supertest": "^7.0.0",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.3",
@@ -593,6 +599,246 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
+      "integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.2",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -645,6 +891,44 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -943,6 +1227,13 @@
         "win32"
       ]
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1135,6 +1426,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -1243,6 +1548,367 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.42.0.tgz",
+      "integrity": "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/type-utils": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.42.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
+      "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
+      "integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.42.0",
+        "@typescript-eslint/types": "^8.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
+      "integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
+      "integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.42.0.tgz",
+      "integrity": "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
+      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
+      "integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.42.0",
+        "@typescript-eslint/tsconfig-utils": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.42.0.tgz",
+      "integrity": "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
+      "integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
@@ -1343,6 +2009,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -1390,6 +2066,23 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -1494,11 +2187,140 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -1524,12 +2346,38 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1642,6 +2490,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1713,6 +2574,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1740,6 +2620,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -1781,6 +2671,39 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -2033,6 +2956,60 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2062,6 +3039,49 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -2135,6 +3155,19 @@
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -2317,6 +3350,75 @@
         }
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2361,6 +3463,37 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -2411,6 +3544,444 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
+      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.35.0",
+        "@eslint/plugin-kit": "^0.3.5",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2419,6 +3990,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2558,12 +4139,73 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -2597,6 +4239,32 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -2628,6 +4296,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fluent-ffmpeg": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
@@ -2657,6 +4346,22 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -2806,6 +4511,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2875,6 +4611,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -2909,6 +4663,49 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2927,6 +4724,65 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -3062,6 +4918,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3079,6 +4972,21 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3088,6 +4996,167 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3095,6 +5164,139 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -3108,6 +5310,103 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -3130,6 +5429,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -3141,6 +5487,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/lazystream": {
@@ -3187,6 +5543,20 @@
       "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/listenercount": {
@@ -3252,6 +5622,13 @@
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
@@ -3321,6 +5698,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -3328,6 +5715,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -3392,8 +5793,8 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3461,6 +5862,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -3575,6 +5983,90 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -3610,6 +6102,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -3664,6 +6192,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3701,6 +6242,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -3737,6 +6285,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -3763,6 +6324,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -3792,6 +6363,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -3852,6 +6449,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
@@ -3968,6 +6575,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4046,6 +6674,50 @@
         "node": ">=10"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4061,6 +6733,37 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
     },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4069,6 +6772,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
@@ -4127,6 +6841,57 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4147,11 +6912,66 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -4212,6 +7032,55 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -4505,6 +7374,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4528,6 +7411,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4540,6 +7482,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -4548,6 +7500,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4639,6 +7604,32 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -4700,6 +7691,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4723,6 +7727,19 @@
       "optional": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-node": {
@@ -4769,6 +7786,19 @@
         }
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4796,6 +7826,19 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -4819,6 +7862,84 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -4839,6 +7960,25 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
@@ -4925,6 +8065,16 @@
       "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5686,11 +8836,107 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -5707,6 +8953,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/webhook-ai/package.json
+++ b/webhook-ai/package.json
@@ -7,7 +7,9 @@
     "dev": "tsx src/app.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/app.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "eslint --config eslint.config.mjs \"src/**/*.{ts,js}\" \"test/**/*.ts\" --max-warnings=0",
+    "format": "prettier --write \"src/**/*.{ts,js}\" \"test/**/*.ts\""
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.10",
@@ -24,6 +26,12 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.9",
     "@types/supertest": "^2.0.16",
+    "@typescript-eslint/eslint-plugin": "^8.42.0",
+    "@typescript-eslint/parser": "^8.42.0",
+    "eslint": "^9.35.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
+    "prettier": "^3.6.2",
     "supertest": "^7.0.0",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.3",
@@ -32,6 +40,8 @@
     "vitest": "^1.6.0"
   },
   "vitest": {
-    "setupFiles": ["./test/setup.ts"]
+    "setupFiles": [
+      "./test/setup.ts"
+    ]
   }
 }

--- a/webhook-ai/src/app.ts
+++ b/webhook-ai/src/app.ts
@@ -24,7 +24,10 @@ const app = express();
 app.use(json({ limit: '2mb' }));
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+  res.header(
+    'Access-Control-Allow-Headers',
+    'Origin, X-Requested-With, Content-Type, Accept, Authorization'
+  );
   res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   if (req.method === 'OPTIONS') return res.sendStatus(204);
   next();
@@ -35,15 +38,26 @@ app.use('/pause', pauseRouter);
 
 // Test mode routes
 app.get('/test-mode/status', (_req, res) => {
-  import('./services/testMode.js').then(m => res.json(m.getTestModeStatus())).catch(()=>res.status(500).json({error:true}));
+  import('./services/testMode.js')
+    .then((m) => res.json(m.getTestModeStatus()))
+    .catch(() => res.status(500).json({ error: true }));
 });
 app.post('/test-mode/enable', (_req, res) => {
-  import('./services/testMode.js').then(m => { m.setTestModeEnabled(true); res.json({ ok: true }); }).catch(()=>res.status(500).json({ok:false}));
+  import('./services/testMode.js')
+    .then((m) => {
+      m.setTestModeEnabled(true);
+      res.json({ ok: true });
+    })
+    .catch(() => res.status(500).json({ ok: false }));
 });
 app.post('/test-mode/disable', (_req, res) => {
-  import('./services/testMode.js').then(m => { m.setTestModeEnabled(false); res.json({ ok: true }); }).catch(()=>res.status(500).json({ok:false}));
+  import('./services/testMode.js')
+    .then((m) => {
+      m.setTestModeEnabled(false);
+      res.json({ ok: true });
+    })
+    .catch(() => res.status(500).json({ ok: false }));
 });
-
 
 app.get('/health', async (_req, res) => {
   try {
@@ -57,7 +71,9 @@ app.get('/health', async (_req, res) => {
       const sb = createClient(url, key, { auth: { persistSession: false } });
       const { error } = await sb.from('bot_sessions').select('id').limit(1);
       supa = error ? 'error' : 'ok';
-    } catch { supa = 'error'; }
+    } catch {
+      supa = 'error';
+    }
     res.json({ status: 'ok', service: 'webhook-ai', whatsapp: st, supabase: supa });
   } catch (e) {
     res.status(500).json({ status: 'error', message: String(e) });
@@ -100,7 +116,8 @@ app.post('/test-message', async (req, res) => {
     const session = await getOrCreateSession('wa', String(from));
     const reply = await orchestrateInbound(from, body, session);
 
-    const preview = typeof reply === 'string' ? reply.slice(0, 200) : JSON.stringify(reply).slice(0, 200);
+    const preview =
+      typeof reply === 'string' ? reply.slice(0, 200) : JSON.stringify(reply).slice(0, 200);
     console.log('[TEST] Resposta gerada:', preview);
 
     try {
@@ -143,7 +160,8 @@ app.post('/test-real-message', async (req, res) => {
     const reply = await orchestrateInbound(yourRealNumber, messageText);
 
     // Log da resposta
-    const preview = typeof reply === 'string' ? reply.slice(0, 200) : JSON.stringify(reply).slice(0, 200);
+    const preview =
+      typeof reply === 'string' ? reply.slice(0, 200) : JSON.stringify(reply).slice(0, 200);
     console.log('[TEST] 📱 Resposta para mensagem real:', preview);
 
     try {
@@ -160,7 +178,7 @@ app.post('/test-real-message', async (req, res) => {
       from: yourRealNumber,
       message: messageText,
       reply: reply,
-      note: '📱 Simulação de mensagem real - Bot funcionando perfeitamente!'
+      note: '📱 Simulação de mensagem real - Bot funcionando perfeitamente!',
     });
   } catch (error) {
     console.error('[TEST] Erro ao simular mensagem real:', error);
@@ -183,4 +201,3 @@ app.listen(Number(env.PORT), '0.0.0.0', async () => {
     console.error('[WA] init error', e);
   }
 });
-

--- a/webhook-ai/src/routes/aiPreview.ts
+++ b/webhook-ai/src/routes/aiPreview.ts
@@ -9,36 +9,49 @@ export const aiPreviewRouter = Router();
 
 const Body = z.object({
   message: z.string().default('Gere uma resposta de exemplo com base no bloco.'),
-  block: z.object({ key: z.string(), type: z.string().optional(), description: z.string().optional(), data: z.any().optional() })
+  block: z.object({
+    key: z.string(),
+    type: z.string().optional(),
+    description: z.string().optional(),
+    data: z.any().optional(),
+  }),
 });
 
 aiPreviewRouter.post('/preview', async (req, res) => {
   try {
     const parsed = Body.safeParse(req.body);
-    if (!parsed.success) return res.status(400).json({ error: 'invalid_body', issues: parsed.error.errors });
+    if (!parsed.success)
+      return res.status(400).json({ error: 'invalid_body', issues: parsed.error.errors });
 
     const { message, block } = parsed.data;
     const bot = await getActiveBot();
     const llm = (bot as any)?.llm || {};
 
-    const sys = buildSystemPrompt((bot as any)?.personality?.systemPrompt, undefined) + '\n\n' +
-      renderBlocksForPrompt([block as KnowledgeBlock]) + '\n\n' +
-      'Instruções: Use o bloco acima como conhecimento para formular uma resposta natural. Não copie textos de mensagens_base literalmente.' + '\n\n' +
+    const sys =
+      buildSystemPrompt((bot as any)?.personality?.systemPrompt, undefined) +
+      '\n\n' +
+      renderBlocksForPrompt([block as KnowledgeBlock]) +
+      '\n\n' +
+      'Instruções: Use o bloco acima como conhecimento para formular uma resposta natural. Não copie textos de mensagens_base literalmente.' +
+      '\n\n' +
       makeToolGuide();
 
-    const provider = (llm.provider || 'openai');
-    const model = provider === 'anthropic'
-      ? (llm.model || process.env.LLM_ANTHROPIC_MODEL || 'claude-3-5-sonnet-20241022')
-      : (llm.model || process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini');
+    const provider = llm.provider || 'openai';
+    const model =
+      provider === 'anthropic'
+        ? llm.model || process.env.LLM_ANTHROPIC_MODEL || 'claude-3-5-sonnet-20241022'
+        : llm.model || process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini';
 
-    const text = await chatComplete({ provider, model, temperature: llm.temperature ?? 0.7, maxTokens: 600 }, [
-      { role: 'system', content: sys },
-      { role: 'user', content: message }
-    ]);
+    const text = await chatComplete(
+      { provider, model, temperature: llm.temperature ?? 0.7, maxTokens: 600 },
+      [
+        { role: 'system', content: sys },
+        { role: 'user', content: message },
+      ]
+    );
 
     return res.json({ ok: true, preview: (text || '').trim() });
   } catch (e: any) {
     return res.status(500).json({ error: true, message: e?.message || String(e) });
   }
 });
-

--- a/webhook-ai/src/routes/pause.ts
+++ b/webhook-ai/src/routes/pause.ts
@@ -16,4 +16,3 @@ pauseRouter.post('/resume', (_req, res) => {
   setGlobalPause(false);
   res.json({ ok: true, paused: false });
 });
-

--- a/webhook-ai/src/routes/whatsapp.ts
+++ b/webhook-ai/src/routes/whatsapp.ts
@@ -36,7 +36,6 @@ whatsappRouter.get('/qr-image', (_req, res) => {
   res.send(html);
 });
 
-
 whatsappRouter.post('/reset', async (_req, res) => {
   await waClient.reset();
   res.json({ ok: true });
@@ -100,4 +99,3 @@ whatsappRouter.post('/reset', async (_req, res) => {
     res.status(500).json({ error: true, message: e?.message || String(e) });
   }
 });
-

--- a/webhook-ai/src/scripts/import-training.ts
+++ b/webhook-ai/src/scripts/import-training.ts
@@ -5,22 +5,33 @@ import fs from 'fs';
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-const TRAIN_DIR = process.env.TRAIN_DIR || path.resolve(process.cwd(), '../../docs/Treinamento Bot');
+const TRAIN_DIR =
+  process.env.TRAIN_DIR || path.resolve(process.cwd(), '../../docs/Treinamento Bot');
 
-async function main(){
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY){
+async function main() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
     console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
     process.exit(1);
   }
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const blocks = parseDirectory(TRAIN_DIR);
-  for (const b of blocks){
-    const { error } = await supabase.from('bot_knowledge_blocks').upsert({ key: b.key, type: b.type, description: b.description, data: b.data, enabled: true });
+  for (const b of blocks) {
+    const { error } = await supabase
+      .from('bot_knowledge_blocks')
+      .upsert({
+        key: b.key,
+        type: b.type,
+        description: b.description,
+        data: b.data,
+        enabled: true,
+      });
     if (error) console.error('Upsert error', b.key, error.message);
     else console.log('Upserted', b.key);
   }
   console.log('Done.');
 }
 
-main().catch(err=>{ console.error(err); process.exit(1); });
-
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/webhook-ai/src/services/botConfig.ts
+++ b/webhook-ai/src/services/botConfig.ts
@@ -1,11 +1,16 @@
 import { supabase } from './supabase.js';
 
-const USE_MOCK = (process.env.MOCK_SUPABASE === 'true');
+const USE_MOCK = process.env.MOCK_SUPABASE === 'true';
 
 export async function getActiveBot() {
   if (USE_MOCK) {
     // Retorna um bot mínimo para testes, evitando chamadas reais ao Supabase
-    return { id: 'test-bot', blocks: [], updated_at: new Date().toISOString(), created_at: new Date().toISOString() } as any;
+    return {
+      id: 'test-bot',
+      blocks: [],
+      updated_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    } as any;
   }
   // Busca a última configuração do bot (mais recente por updated_at/created_at)
   const { data, error } = await supabase
@@ -39,4 +44,3 @@ export function renderTemplate(content: string, vars: Record<string, string>) {
     return vars[key] ?? '';
   });
 }
-

--- a/webhook-ai/src/services/chains.ts
+++ b/webhook-ai/src/services/chains.ts
@@ -25,16 +25,20 @@ export async function fetchNeuralChains(): Promise<NeuralChain[]> {
 
 function includesAny(text: string, terms: string[]): boolean {
   const b = text.toLowerCase();
-  return terms.some(t => b.includes(String(t || '').toLowerCase()));
+  return terms.some((t) => b.includes(String(t || '').toLowerCase()));
 }
 
-export function activateChains(chains: NeuralChain[], message: string, session?: SessionRecord): ChainDirectives {
+export function activateChains(
+  chains: NeuralChain[],
+  message: string,
+  session?: SessionRecord
+): ChainDirectives {
   const base: ChainDirectives = { prefer_services: [], allowed_tools: [], boost_blocks: [] };
   const stage = (session as any)?.state?.funil_etapa || null;
   for (const c of chains) {
     const act = c.activation || {};
     const okTerms = Array.isArray(act.termsAny) ? includesAny(message, act.termsAny) : true;
-    const okStage = Array.isArray(act.stageAny) ? (!stage || act.stageAny.includes(stage)) : true;
+    const okStage = Array.isArray(act.stageAny) ? !stage || act.stageAny.includes(stage) : true;
     if (okTerms && okStage) {
       const run = c.run_config || {};
       if (Array.isArray(run.prefer_services)) base.prefer_services.push(...run.prefer_services);
@@ -51,10 +55,11 @@ export function activateChains(chains: NeuralChain[], message: string, session?:
 
 export function renderDirectivesForPrompt(d: ChainDirectives): string {
   const lines: string[] = [];
-  if (d.prefer_services.length) lines.push(`Serviços preferenciais para este caso: ${d.prefer_services.join(', ')}`);
+  if (d.prefer_services.length)
+    lines.push(`Serviços preferenciais para este caso: ${d.prefer_services.join(', ')}`);
   if (d.allowed_tools.length) lines.push(`Ferramentas permitidas: ${d.allowed_tools.join(', ')}`);
-  if (d.boost_blocks.length) lines.push(`Priorize conhecimento dos blocos: ${d.boost_blocks.join(', ')}`);
+  if (d.boost_blocks.length)
+    lines.push(`Priorize conhecimento dos blocos: ${d.boost_blocks.join(', ')}`);
   if (!lines.length) return '';
   return `Diretrizes de execução (neural chain):\n${lines.join('\n')}`;
 }
-

--- a/webhook-ai/src/services/conversation.ts
+++ b/webhook-ai/src/services/conversation.ts
@@ -24,7 +24,10 @@ export async function ensureThread(contact: string, channel: 'whatsapp' | 'web' 
     .insert({ bot_id, contact, channel })
     .select('id')
     .single();
-  if (error) { console.error('[conversation] create thread error', error); return null; }
+  if (error) {
+    console.error('[conversation] create thread error', error);
+    return null;
+  }
   return data.id as string;
 }
 
@@ -35,7 +38,7 @@ export async function logInbound(contact: string, content: string) {
     thread_id: threadId,
     direction: 'inbound',
     type: 'text',
-    content
+    content,
   });
 }
 
@@ -46,7 +49,7 @@ export async function logOutbound(contact: string, content: string) {
     thread_id: threadId,
     direction: 'outbound',
     type: 'text',
-    content
+    content,
   });
 }
 
@@ -70,4 +73,3 @@ export async function closeThread(contact: string) {
     .update({ closed_at: new Date().toISOString() })
     .eq('id', thread.id);
 }
-

--- a/webhook-ai/src/services/conversationOrchestrator.ts
+++ b/webhook-ai/src/services/conversationOrchestrator.ts
@@ -3,116 +3,289 @@ import { getActiveBot } from './botConfig.js';
 import { makeToolGuide } from './tools.js';
 import { getIntents } from './intentRegistry.js';
 import { setSessionState, SessionRecord } from './sessionStore.js';
-import { extractBlocks, findRelevantBlocks, renderBlocksForPrompt, fetchKnowledgeBlocks } from './knowledge.js';
+import {
+  extractBlocks,
+  findRelevantBlocks,
+  renderBlocksForPrompt,
+  fetchKnowledgeBlocks,
+} from './knowledge.js';
 import { fetchNeuralChains, activateChains, renderDirectivesForPrompt } from './chains.js';
-import { fetchServicePolicies, getPreferredServicesForEquipment, getOfferMessageForServiceType } from './policies.js';
+import {
+  fetchServicePolicies,
+  getPreferredServicesForEquipment,
+  getOfferMessageForServiceType,
+} from './policies.js';
 import { supabase } from './supabase.js';
 
-async function logAIRoute(event: string, payload: any){
-  try{
+async function logAIRoute(event: string, payload: any) {
+  try {
     await supabase.from('bot_ai_router_logs').insert({
-      event, payload,
-      created_at: new Date().toISOString()
+      event,
+      payload,
+      created_at: new Date().toISOString(),
     } as any);
-  }catch(e){ console.warn('[AI-ROUTER-LOG] Failed', e); }
+  } catch (e) {
+    console.warn('[AI-ROUTER-LOG] Failed', e);
+  }
 }
 
 function detectPriorityIntent(text: string): string | null {
-  const normalize = (s:string)=> s.normalize('NFD').replace(/\p{Diacritic}/gu,'').toLowerCase();
-  const b = normalize(text||'');
-  if (/(\breagendar\b|\breagendamento\b|trocar horario|nova data|remarcar)/.test(b)) return 'reagendamento';
+  const normalize = (s: string) =>
+    s
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .toLowerCase();
+  const b = normalize(text || '');
+  if (/(\breagendar\b|\breagendamento\b|trocar horario|nova data|remarcar)/.test(b))
+    return 'reagendamento';
   if (/(\bcancelar\b|\bcancelamento\b|desmarcar)/.test(b)) return 'cancelamento';
-  if (/(\bstatus\b|acompanhar|andamento|numero da os|n\u00ba da os|numero da ordem)/.test(b)) return 'status_ordem';
+  if (/(\bstatus\b|acompanhar|andamento|numero da os|n\u00ba da os|numero da ordem)/.test(b))
+    return 'status_ordem';
   if (/(instalar|instalacao|instala\u00e7\u00e3o)/.test(b)) return 'instalacao';
   return null;
 }
 
-
-
-function guessFunnelFields(text: string){
-  const normalize = (s:string)=> s.normalize('NFD').replace(/\p{Diacritic}/gu,'');
-  const braw = (text||'');
+function guessFunnelFields(text: string) {
+  const normalize = (s: string) => s.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+  const braw = text || '';
   const b = normalize(braw.toLowerCase());
   const equipamentos = [
     // Fogão / Forno
-    'fogão','fogao',
-    'forno','forno elétrico','forno eletrico','forno a gás','forno a gas','forno de embutir','forno embutir',
+    'fogão',
+    'fogao',
+    'forno',
+    'forno elétrico',
+    'forno eletrico',
+    'forno a gás',
+    'forno a gas',
+    'forno de embutir',
+    'forno embutir',
     // Cooktop
-    'cooktop','cook top','cook-top',
+    'cooktop',
+    'cook top',
+    'cook-top',
     // Micro-ondas
-    'micro-ondas','microondas','micro ondas','micro ondas','forno microondas','forno micro-ondas','forno de microondas','micro ondas','microondas embutido','micro-ondas embutido','microondas bancada','micro-ondas bancada',
+    'micro-ondas',
+    'microondas',
+    'micro ondas',
+    'micro ondas',
+    'forno microondas',
+    'forno micro-ondas',
+    'forno de microondas',
+    'micro ondas',
+    'microondas embutido',
+    'micro-ondas embutido',
+    'microondas bancada',
+    'micro-ondas bancada',
     // Lava-louças (variações sing/plural, com/sem hífen e cedilha)
-    'lava louças','lava-louças','lava louça','lava-louça','lava-louca','lava louca',
-    'lavalouças','lavalouça','lava loucas','lava-loucas','lavaloucas','lavalouca',
-    'máquina de lavar louças','maquina de lavar loucas','máquina lavar louças','maquina lavar loucas',
+    'lava louças',
+    'lava-louças',
+    'lava louça',
+    'lava-louça',
+    'lava-louca',
+    'lava louca',
+    'lavalouças',
+    'lavalouça',
+    'lava loucas',
+    'lava-loucas',
+    'lavaloucas',
+    'lavalouca',
+    'máquina de lavar louças',
+    'maquina de lavar loucas',
+    'máquina lavar louças',
+    'maquina lavar loucas',
     // Lava-roupas / Lavadora
-    'lava roupas','lava-roupas','lavadora','lavadora de roupas','máquina de lavar','maquina de lavar','máquina lavar','maquina lavar','máquina de lavar roupas','maquina de lavar roupas',
+    'lava roupas',
+    'lava-roupas',
+    'lavadora',
+    'lavadora de roupas',
+    'máquina de lavar',
+    'maquina de lavar',
+    'máquina lavar',
+    'maquina lavar',
+    'máquina de lavar roupas',
+    'maquina de lavar roupas',
     // Lava e seca
-    'lava e seca','lava-seca','lava & seca','lava&seca','lava seca',
+    'lava e seca',
+    'lava-seca',
+    'lava & seca',
+    'lava&seca',
+    'lava seca',
     // Secadora
-    'secadora','secadora de roupas',
+    'secadora',
+    'secadora de roupas',
     // Coifa
-    'coifa','exaustor','depurador',
+    'coifa',
+    'exaustor',
+    'depurador',
     // Adega
-    'adega','adega climatizada','adega de vinhos','adega de vinho'
+    'adega',
+    'adega climatizada',
+    'adega de vinhos',
+    'adega de vinho',
   ];
-  const marcas = ['brastemp','consul','electrolux','lg','samsung','bosch','midea','philco','fischer','mueller','ge','continental'];
+  const marcas = [
+    'brastemp',
+    'consul',
+    'electrolux',
+    'lg',
+    'samsung',
+    'bosch',
+    'midea',
+    'philco',
+    'fischer',
+    'mueller',
+    'ge',
+    'continental',
+  ];
 
   // Extrair TODOS os equipamentos encontrados (não apenas o primeiro)
   const equipamentosEncontrados: string[] = [];
-  for (const e of equipamentos){
+  for (const e of equipamentos) {
     if (b.includes(e)) {
-      equipamentosEncontrados.push(e.replace('fogao','fogão'));
+      equipamentosEncontrados.push(e.replace('fogao', 'fogão'));
     }
   }
 
-  let marca: string|undefined;
-  for (const m of marcas){ if (b.includes(m)) { marca = m; break; } }
+  let marca: string | undefined;
+  for (const m of marcas) {
+    if (b.includes(m)) {
+      marca = m;
+      break;
+    }
+  }
   // Problema: pegar trecho conhecido
   const problemas = [
     // acendimento/ligar
-    'não acende','nao acende','não liga','nao liga','sem chama','faísca fraca','faisca fraca','boca não acende','boca nao acende','boca não funciona','boca nao funciona',
+    'não acende',
+    'nao acende',
+    'não liga',
+    'nao liga',
+    'sem chama',
+    'faísca fraca',
+    'faisca fraca',
+    'boca não acende',
+    'boca nao acende',
+    'boca não funciona',
+    'boca nao funciona',
     // força/cor da chama
-    'chama fraca','chamas fracas','chama baixa','fogo fraco','boca fraca','bocas fracas','duas bocas fracas','duas chamas fracas','2 chamas fracas',
-    'chama amarela','chamas amarelas','fogo amarelo','fogo amarelado',
+    'chama fraca',
+    'chamas fracas',
+    'chama baixa',
+    'fogo fraco',
+    'boca fraca',
+    'bocas fracas',
+    'duas bocas fracas',
+    'duas chamas fracas',
+    '2 chamas fracas',
+    'chama amarela',
+    'chamas amarelas',
+    'fogo amarelo',
+    'fogo amarelado',
     // quantidade de bocas com defeito
-    '2 bocas','duas bocas','duas bocas não funcionam','duas bocas nao funcionam','duas bocas não acendem','duas bocas nao acendem',
+    '2 bocas',
+    'duas bocas',
+    'duas bocas não funcionam',
+    'duas bocas nao funcionam',
+    'duas bocas não acendem',
+    'duas bocas nao acendem',
     // gás/cheiro
-    'vazando gás','vazamento de gás','cheiro de gás','cheiro de gas',
+    'vazando gás',
+    'vazamento de gás',
+    'cheiro de gás',
+    'cheiro de gas',
     // aquecimento/barulho
-    'não esquenta','nao esquenta','faz barulho','não funciona','nao funciona',
+    'não esquenta',
+    'nao esquenta',
+    'faz barulho',
+    'não funciona',
+    'nao funciona',
     // água/entrada/saída (lava-louças, lavadora)
-    'não entra água','nao entra agua','não puxa água','nao puxa agua','não enche','nao enche','não drena','nao drena','não escoa','nao escoa','vazando água','vazando agua','vaza água','vaza agua',
+    'não entra água',
+    'nao entra agua',
+    'não puxa água',
+    'nao puxa agua',
+    'não enche',
+    'nao enche',
+    'não drena',
+    'nao drena',
+    'não escoa',
+    'nao escoa',
+    'vazando água',
+    'vazando agua',
+    'vaza água',
+    'vaza agua',
     // centrifugação/secagem/porta
-    'não centrifuga','nao centrifuga','não seca','nao seca','não aquece','nao aquece','porta não fecha','porta nao fecha','porta não trava','porta nao trava','trava da porta'
+    'não centrifuga',
+    'nao centrifuga',
+    'não seca',
+    'nao seca',
+    'não aquece',
+    'nao aquece',
+    'porta não fecha',
+    'porta nao fecha',
+    'porta não trava',
+    'porta nao trava',
+    'trava da porta',
   ];
-  let problema: string|undefined;
-  for (const p of problemas){ if (b.includes(p)) { problema = p; break; } }
+  let problema: string | undefined;
+  for (const p of problemas) {
+    if (b.includes(p)) {
+      problema = p;
+      break;
+    }
+  }
 
   // Detectar total de bocas (4/5/6) do equipamento (não confundir com bocas com defeito)
-  let num_burners: string|undefined;
+  let num_burners: string | undefined;
   const m = b.match(/(?:\b|^)(4|5|6)\s*bocas?\b/);
   if (m) {
     num_burners = m[1];
   } else {
-    const words: Record<string,string> = { 'quatro':'4', 'cinco':'5', 'seis':'6' };
-    for (const [w,n] of Object.entries(words)){
-      if (b.includes(`${w} bocas`) || b.includes(`${w} boca`)) { num_burners = n; break; }
+    const words: Record<string, string> = { quatro: '4', cinco: '5', seis: '6' };
+    for (const [w, n] of Object.entries(words)) {
+      if (b.includes(`${w} bocas`) || b.includes(`${w} boca`)) {
+        num_burners = n;
+        break;
+      }
     }
   }
 
   // Retornar primeiro equipamento para compatibilidade, mas também a lista completa
   const equipamento = equipamentosEncontrados[0];
   return { equipamento, equipamentosEncontrados, marca, problema, num_burners };
-function guessAcceptance(text: string){
-  const b = (text||'').toLowerCase();
-  const yes = ['sim','pode ser','pode agendar','quero','vamos','fechado','ok','ok pode','tá bom','ta bom','bora','aceito','aceitamos','pode marcar','marca'];
-  const no = ['não','nao','prefiro não','prefiro nao','depois eu vejo','mais tarde','talvez'];
-  if (no.some(w => b.includes(w))) return { accepted: false };
-  if (yes.some(w => b.includes(w))) return { accepted: true };
-  return { accepted: undefined };
-}
-
+  function guessAcceptance(text: string) {
+    const b = (text || '').toLowerCase();
+    const yes = [
+      'sim',
+      'pode ser',
+      'pode agendar',
+      'quero',
+      'vamos',
+      'fechado',
+      'ok',
+      'ok pode',
+      'tá bom',
+      'ta bom',
+      'bora',
+      'aceito',
+      'aceitamos',
+      'pode marcar',
+      'marca',
+    ];
+    const no = [
+      'não',
+      'nao',
+      'prefiro não',
+      'prefiro nao',
+      'depois eu vejo',
+      'mais tarde',
+      'talvez',
+    ];
+    if (no.some((w) => b.includes(w))) return { accepted: false };
+    if (yes.some((w) => b.includes(w))) return { accepted: true };
+    return { accepted: undefined };
+  }
 }
 
 function simpleIntent(text: string): string {
@@ -133,14 +306,30 @@ function hasExplicitAcceptance(text: string): boolean {
   const b = original.toLowerCase();
   // Padrões claros de aceite
   const phrases = [
-    'pode agendar','pode marcar','ok pode agendar','ok pode marcar',
-    'aceito','aceito o orçamento','aceito o orcamento',
-    'fechado','fechou','pode vir','pode prosseguir','pode seguir',
-    'vamos agendar','vamos marcar','quero agendar','quero marcar',
-    'gostaria de agendar','gostaria de marcar','gostaria agendar','gostaria marcar',
-    'confirmo','confirmar agendamento'
+    'pode agendar',
+    'pode marcar',
+    'ok pode agendar',
+    'ok pode marcar',
+    'aceito',
+    'aceito o orçamento',
+    'aceito o orcamento',
+    'fechado',
+    'fechou',
+    'pode vir',
+    'pode prosseguir',
+    'pode seguir',
+    'vamos agendar',
+    'vamos marcar',
+    'quero agendar',
+    'quero marcar',
+    'gostaria de agendar',
+    'gostaria de marcar',
+    'gostaria agendar',
+    'gostaria marcar',
+    'confirmo',
+    'confirmar agendamento',
   ];
-  if (phrases.some(p => b.includes(p))) return true;
+  if (phrases.some((p) => b.includes(p))) return true;
   // "sim" isolado (apenas quando a mensagem é só "sim" com possíveis pontuações)
   if (/^\s*sim\s*[!.…)?]*\s*$/i.test(original)) return true;
   return false;
@@ -148,29 +337,35 @@ function hasExplicitAcceptance(text: string): boolean {
 
 // FUNÇÃO DINÂMICA DE VERIFICAÇÃO DE AMBIGUIDADE
 type AmbiguityPrompt = { text: string; options: Array<{ id: string; text: string }> };
-async function checkEquipmentAmbiguity(body: string, session: any): Promise<string | AmbiguityPrompt | null> {
+async function checkEquipmentAmbiguity(
+  body: string,
+  session: any
+): Promise<string | AmbiguityPrompt | null> {
   if (!body) return null;
 
   // Normalizar texto removendo acentos e caracteres especiais de forma robusta
   const normalize = (s: string) => {
-    return s.normalize('NFD')
-      .replace(/\p{Diacritic}/gu, '')
-      .replace(/[àáâãäå]/g, 'a')
-      .replace(/[èéêë]/g, 'e')
-      .replace(/[ìíîï]/g, 'i')
-      .replace(/[òóôõö]/g, 'o')
-      .replace(/[ùúûü]/g, 'u')
-      .replace(/[ç]/g, 'c')
-      .replace(/[ñ]/g, 'n')
-      .replace(/[ý]/g, 'y')
-      // Tratar caracteres corrompidos específicos
-      .replace(/fog�o/g, 'fogao')
-      .replace(/n�o/g, 'nao')
-      .replace(/indu��o/g, 'inducao')
-      .replace(/el�trico/g, 'eletrico')
-      .replace(/�/g, '') // remover caracteres de substituição
-      .toLowerCase()
-      .trim();
+    return (
+      s
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replace(/[àáâãäå]/g, 'a')
+        .replace(/[èéêë]/g, 'e')
+        .replace(/[ìíîï]/g, 'i')
+        .replace(/[òóôõö]/g, 'o')
+        .replace(/[ùúûü]/g, 'u')
+        .replace(/[ç]/g, 'c')
+        .replace(/[ñ]/g, 'n')
+        .replace(/[ý]/g, 'y')
+        // Tratar caracteres corrompidos específicos
+        .replace(/fog�o/g, 'fogao')
+        .replace(/n�o/g, 'nao')
+        .replace(/indu��o/g, 'inducao')
+        .replace(/el�trico/g, 'eletrico')
+        .replace(/�/g, '') // remover caracteres de substituição
+        .toLowerCase()
+        .trim()
+    );
   };
 
   const normalized = normalize(body);
@@ -181,7 +376,10 @@ async function checkEquipmentAmbiguity(body: string, session: any): Promise<stri
       const prev = (session as any)?.state?.dados_coletados || {};
       const dados = { ...prev, equipamento: 'fogão a gás' };
       if ((session as any)?.id) {
-        await setSessionState((session as any).id, { ...(session as any).state, dados_coletados: dados });
+        await setSessionState((session as any).id, {
+          ...(session as any).state,
+          dados_coletados: dados,
+        });
       }
       return null;
     }
@@ -196,7 +394,10 @@ async function checkEquipmentAmbiguity(body: string, session: any): Promise<stri
     const st = (session as any)?.state || {};
     const pending = st.pendingEquipmentType as string | undefined;
     if (pending) {
-      const text = (body || '').normalize('NFD').replace(/\p{Diacritic}/gu,'').toLowerCase(); // já normalizado sem acentos
+      const text = (body || '')
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .toLowerCase(); // já normalizado sem acentos
       const numMatch = text.match(/^\s*([123])\s*$/);
       const n = numMatch ? numMatch[1] : undefined;
       let equip: string | undefined;
@@ -209,14 +410,25 @@ async function checkEquipmentAmbiguity(body: string, session: any): Promise<stri
         if (n === '1' || /\bgas\b/.test(text)) equip = 'fogão a gás';
         else if (n === '2' || /eletric/.test(text)) equip = 'fogão elétrico';
         else if (n === '3' || /inducao|\bindu\b/.test(text)) equip = 'fogão de indução';
-      } else if (pending === 'microondas' || pending === 'micro-ondas' || pending === 'micro ondas') {
+      } else if (
+        pending === 'microondas' ||
+        pending === 'micro-ondas' ||
+        pending === 'micro ondas'
+      ) {
         if (n === '1' || /bancada/.test(text)) equip = 'micro-ondas';
         else if (n === '2' || /embut/.test(text)) equip = 'micro-ondas';
       }
 
       if (equip) {
         const dadosPrev = st.dados_coletados || {};
-        setSessionState((session as any).id, { ...st, pendingEquipmentType: null, dados_coletados: { ...dadosPrev, equipamento: equip }, orcamento_entregue: false, last_quote: null, last_quote_ts: null });
+        setSessionState((session as any).id, {
+          ...st,
+          pendingEquipmentType: null,
+          dados_coletados: { ...dadosPrev, equipamento: equip },
+          orcamento_entregue: false,
+          last_quote: null,
+          last_quote_ts: null,
+        });
         return null;
       }
     }
@@ -253,14 +465,19 @@ async function checkEquipmentAmbiguity(body: string, session: any): Promise<stri
     }
   } catch {}
 
-
   // 🏭 VERIFICAÇÃO PRÉVIA DE EQUIPAMENTOS INDUSTRIAIS (ANTES DA DETECÇÃO DE AMBIGUIDADE)
-  const isIndustrialAtendemos = /(fog[aã]o\s*industrial|forno\s*industrial|industrial.*(?:4|5|6|8)\s*bocas?)/i.test(lower) ||
-                                /(geladeira\s*comercial|refrigerador\s*comercial)/i.test(lower) ||
-                                /((?:4|5|6|8)\s*bocas?.*industrial|industrial.*(?:4|5|6|8)\s*bocas?)/i.test(lower) ||
-                                /(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno)/i.test(lower) ||
-                                /(forno.*m[eé]dio.*porte|m[eé]dio.*porte.*forno|forno.*medio.*porte|medio.*porte.*forno)/i.test(lower);
-  const isIndustrialNaoAtendemos = /(forno.*esteira|esteira.*forno|linha.*produção|produção.*linha|forno.*grande.*porte|grande.*porte.*forno)/i.test(lower);
+  const isIndustrialAtendemos =
+    /(fog[aã]o\s*industrial|forno\s*industrial|industrial.*(?:4|5|6|8)\s*bocas?)/i.test(lower) ||
+    /(geladeira\s*comercial|refrigerador\s*comercial)/i.test(lower) ||
+    /((?:4|5|6|8)\s*bocas?.*industrial|industrial.*(?:4|5|6|8)\s*bocas?)/i.test(lower) ||
+    /(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno)/i.test(lower) ||
+    /(forno.*m[eé]dio.*porte|m[eé]dio.*porte.*forno|forno.*medio.*porte|medio.*porte.*forno)/i.test(
+      lower
+    );
+  const isIndustrialNaoAtendemos =
+    /(forno.*esteira|esteira.*forno|linha.*produção|produção.*linha|forno.*grande.*porte|grande.*porte.*forno)/i.test(
+      lower
+    );
 
   // 🔍 Log da detecção industrial (apenas para equipamentos que atendemos)
   if (isIndustrialAtendemos) {
@@ -276,36 +493,53 @@ async function checkEquipmentAmbiguity(body: string, session: any): Promise<stri
 
   // 🚫 Equipamentos não atendidos (eletroportáteis)
   // Detecta menções a itens que não prestamos assistência para evitar respostas contraditórias (ex.: não ofertar agendamento)
-  const isUnsupportedPortable = /\b(air[-\s]*fryer|fritadeir[ae](?:\s*sem\s*[óo]leo)?(?:\s*el[eé]trica)?|cafeteira|caf[eé]|liquidificador|batedeira|sanduicheira|grill\s*el[eé]trico|torradeira|processador\s*de\s*alimentos|secador\s*de\s*cabelo|chapinha|prancha\s*de\s*cabelo|ventilador|ferro\s*de\s*passar|aspirador(?:\s*de\s*p[oó])?|umidificador|purificador\s*de\s*[áa]gua|torneira\s*el[eé]trica|bebedouro|impressora|televis[aã]o|tv\b)\b/i.test(lower);
+  const isUnsupportedPortable =
+    /\b(air[-\s]*fryer|fritadeir[ae](?:\s*sem\s*[óo]leo)?(?:\s*el[eé]trica)?|cafeteira|caf[eé]|liquidificador|batedeira|sanduicheira|grill\s*el[eé]trico|torradeira|processador\s*de\s*alimentos|secador\s*de\s*cabelo|chapinha|prancha\s*de\s*cabelo|ventilador|ferro\s*de\s*passar|aspirador(?:\s*de\s*p[oó])?|umidificador|purificador\s*de\s*[áa]gua|torneira\s*el[eé]trica|bebedouro|impressora|televis[aã]o|tv\b)\b/i.test(
+      lower
+    );
 
   if (isUnsupportedPortable) {
     return 'Desculpe, no momento não atendemos eletroportáteis (ex.: air fryer, cafeteira, liquidificador). Trabalhamos com fogões, fornos/cooktops, micro-ondas, geladeiras, lavadoras/lava e seca/secadoras, lava-louças e coifas. Posso ajudar com algum desses?';
   }
-
 
   // Definir equipamentos ambíguos e suas variações (normalizadas)
   const ambiguousEquipments = [
     {
       keywords: ['fogao', 'fogão'], // normalizado: fogao
       types: ['gas', 'gás', 'gs', 'a gas', 'a gs', 'inducao', 'indução', 'eletrico', 'elétrico'],
-      question: 'É um fogão a gás, de indução ou elétrico?'
+      question: 'É um fogão a gás, de indução ou elétrico?',
     },
     {
       keywords: ['microondas', 'micro-ondas', 'micro ondas'],
       types: ['bancada', 'embutido', 'embut'],
-      question: 'É um microondas de bancada ou embutido?'
+      question: 'É um microondas de bancada ou embutido?',
     },
     {
       keywords: ['forno'],
-      types: ['embutido', 'embut', 'bancada', 'eletrico', 'elétrico', 'gas', 'gás', 'industrial', 'fogao', 'fogão', 'piso', 'de piso'],
-      question: 'É o forno do fogão a gás (de piso) ou um forno elétrico (embutido ou de bancada)?'
-    }
+      types: [
+        'embutido',
+        'embut',
+        'bancada',
+        'eletrico',
+        'elétrico',
+        'gas',
+        'gás',
+        'industrial',
+        'fogao',
+        'fogão',
+        'piso',
+        'de piso',
+      ],
+      question: 'É o forno do fogão a gás (de piso) ou um forno elétrico (embutido ou de bancada)?',
+    },
   ];
 
   // Verificar se há equipamento ambíguo na mensagem
   for (const equipment of ambiguousEquipments) {
-    const hasEquipment = equipment.keywords.some(keyword => normalized.includes(normalize(keyword)));
-    const hasType = equipment.types.some(type => normalized.includes(normalize(type)));
+    const hasEquipment = equipment.keywords.some((keyword) =>
+      normalized.includes(normalize(keyword))
+    );
+    const hasType = equipment.types.some((type) => normalized.includes(normalize(type)));
 
     // 🏭 PULAR DETECÇÃO DE AMBIGUIDADE PARA EQUIPAMENTOS INDUSTRIAIS JÁ IDENTIFICADOS
     if (hasEquipment && !hasType && !isIndustrialAtendemos) {
@@ -321,7 +555,7 @@ async function checkEquipmentAmbiguity(body: string, session: any): Promise<stri
           setSessionState((session as any).id, {
             ...sessionState,
             lastAmbiguityCheck: now,
-            pendingEquipmentType: equipment.keywords[0]
+            pendingEquipmentType: equipment.keywords[0],
           });
         }
 
@@ -330,23 +564,22 @@ async function checkEquipmentAmbiguity(body: string, session: any): Promise<stri
           ? [
               { id: '1', text: 'Forno do fogão (piso / a gás)' },
               { id: '2', text: 'Forno elétrico embutido' },
-              { id: '3', text: 'Forno elétrico de bancada' }
+              { id: '3', text: 'Forno elétrico de bancada' },
             ]
           : equipment.keywords.includes('fogão') || equipment.keywords.includes('fogao')
-          ? [
-              { id: '1', text: 'Fogão a gás' },
-              { id: '2', text: 'Fogão elétrico' },
-              { id: '3', text: 'Fogão de indução' }
-            ]
-          : equipment.keywords.includes('microondas') || equipment.keywords.includes('micro-ondas')
-          ? [
-              { id: '1', text: 'Micro-ondas de bancada' },
-              { id: '2', text: 'Micro-ondas embutido' }
-            ]
-          : [];
-        return options.length
-          ? { text: equipment.question, options }
-          : equipment.question;
+            ? [
+                { id: '1', text: 'Fogão a gás' },
+                { id: '2', text: 'Fogão elétrico' },
+                { id: '3', text: 'Fogão de indução' },
+              ]
+            : equipment.keywords.includes('microondas') ||
+                equipment.keywords.includes('micro-ondas')
+              ? [
+                  { id: '1', text: 'Micro-ondas de bancada' },
+                  { id: '2', text: 'Micro-ondas embutido' },
+                ]
+              : [];
+        return options.length ? { text: equipment.question, options } : equipment.question;
       }
     }
   }
@@ -359,29 +592,47 @@ function sanitizeSensitiveRequests(text: any, accepted: boolean): string {
   if (accepted) return String(text || '');
   if (!text || typeof text !== 'string') return String(text || '');
   const t = text.toLowerCase();
-  const asksSensitive = /(endereço|endereco|cep|bairro|rua|número|numero|complemento|telefone|cpf|e-mail|email)/i.test(t);
+  const asksSensitive =
+    /(endereço|endereco|cep|bairro|rua|número|numero|complemento|telefone|cpf|e-mail|email)/i.test(
+      t
+    );
   if (!asksSensitive) return text;
-  const cleaned = text.replace(/.*(endere[çc]o|cep|bairro|rua|n[úu]mero|complemento|telefone|cpf|e-?mail).*$/gmi, '').trim();
+  const cleaned = text
+    .replace(/.*(endere[çc]o|cep|bairro|rua|n[úu]mero|complemento|telefone|cpf|e-?mail).*$/gim, '')
+    .trim();
   const suffix = cleaned ? `\n\n` : '';
   return `${cleaned}${suffix}Antes de dados pessoais, vou te passar o valor e o escopo do atendimento. Tudo bem?`;
 }
 
-export async function orchestrateInbound(from: string, body: string, session?: SessionRecord): Promise<string | AmbiguityPrompt | null> {
+export async function orchestrateInbound(
+  from: string,
+  body: string,
+  session?: SessionRecord
+): Promise<string | AmbiguityPrompt | null> {
   console.log('[AI-ROUTER] 🧠 Iniciando roteamento por IA para:', from);
 
   // VERIFICAÇÃO DE AMBIGUIDADE DINÂMICA (PRIMEIRA PRIORIDADE)
   // Guardião para saudações/pequenas falas: evita respostas longas quando o usuário só diz "oi" etc.
   try {
     const text = (body || '').trim();
-    const norm = text.normalize('NFD').replace(/\p{Diacritic}/gu,'').toLowerCase();
-    const isGreetingOnly = /^(ola|oi|bom dia|boa tarde|boa noite|tudo bem|e ai|opa)[.!? ]*$/i.test(norm); // saudação puramente, sem contexto
-    const isJustEquipHint = /^(fogao|fogão|forno|cooktop|micro|adega|lava|secadora|coifa|geladeira)[.!? ]*$/i.test(norm);
+    const norm = text
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .toLowerCase();
+    const isGreetingOnly = /^(ola|oi|bom dia|boa tarde|boa noite|tudo bem|e ai|opa)[.!? ]*$/i.test(
+      norm
+    ); // saudação puramente, sem contexto
+    const isJustEquipHint =
+      /^(fogao|fogão|forno|cooktop|micro|adega|lava|secadora|coifa|geladeira)[.!? ]*$/i.test(norm);
 
-    const hasEquipmentHint = /(fogao|fogão|forno|cooktop|micro|adega|lava|secadora|coifa|geladeira)/i.test(norm);
+    const hasEquipmentHint =
+      /(fogao|fogão|forno|cooktop|micro|adega|lava|secadora|coifa|geladeira)/i.test(norm);
     const tokenCount = norm.split(/\s+/).filter(Boolean).length;
 
     // NOVO: se o usuário disser apenas o tipo ("a gas", "elétrico", "indução") e já houver equipamento na sessão, não retorne saudação
-    const typeOnly = /(\bgas\b|\bgás\b|\beletrico\b|\belétrico\b|\binducao\b|\bindução\b)/i.test(norm) && tokenCount <= 3;
+    const typeOnly =
+      /(\bgas\b|\bgás\b|\beletrico\b|\belétrico\b|\binducao\b|\bindução\b)/i.test(norm) &&
+      tokenCount <= 3;
     const hasEquipInSession = !!(session as any)?.state?.dados_coletados?.equipamento;
     if (typeOnly && hasEquipInSession) {
       // atualiza tipo no estado e segue fluxo normal
@@ -389,13 +640,20 @@ export async function orchestrateInbound(from: string, body: string, session?: S
         const prev = (session as any)?.state?.dados_coletados || {};
         const updated = { ...prev } as any;
         if (/g(á|a)s/.test(norm)) updated.equipamento = 'fogão a gás';
-        else if (/indu(c|ç)ao|indu(c|ç)ão|\bindu\b/.test(norm)) updated.equipamento = 'fogão de indução';
+        else if (/indu(c|ç)ao|indu(c|ç)ão|\bindu\b/.test(norm))
+          updated.equipamento = 'fogão de indução';
         else if (/el(é|e)trico/.test(norm)) updated.equipamento = 'fogão elétrico';
         if ((session as any)?.id) {
-          const newState = { ...(session as any).state, dados_coletados: updated, pendingEquipmentType: null } as any;
+          const newState = {
+            ...(session as any).state,
+            dados_coletados: updated,
+            pendingEquipmentType: null,
+          } as any;
           await setSessionState((session as any).id, newState);
           // manter a cópia local da sessão atualizada para o restante do fluxo
-          try { (session as any).state = newState; } catch {}
+          try {
+            (session as any).state = newState;
+          } catch {}
         }
       } catch {}
     } else if (isGreetingOnly || (!hasEquipmentHint && tokenCount <= 2)) {
@@ -444,14 +702,16 @@ export async function orchestrateInbound(from: string, body: string, session?: S
 
   const configuredIntents = await getIntents();
   const lowered = body.toLowerCase();
-  let intent = configuredIntents.find((it:any)=> (it.examples||[]).some((ex:string)=> lowered.includes(ex.toLowerCase())))?.name;
+  let intent = configuredIntents.find((it: any) =>
+    (it.examples || []).some((ex: string) => lowered.includes(ex.toLowerCase()))
+  )?.name;
   // 2) fallback para heurística simples
   intent = intent || simpleIntent(body);
 
   // Context blocks do bot (podem ter dados estruturados)
   const botBlocks = extractBlocks(bot);
   const blocks = Array.isArray((bot as any)?.contextBlocks)
-    ? ((bot as any).contextBlocks as any[]).filter(b => !b.intents || b.intents.includes(intent))
+    ? ((bot as any).contextBlocks as any[]).filter((b) => !b.intents || b.intents.includes(intent))
     : undefined;
 
   // Regras rápidas desativadas para priorizar LLM natural
@@ -470,7 +730,7 @@ export async function orchestrateInbound(from: string, body: string, session?: S
   let funnelText = '';
 
   // Diretriz de ferramenta específica por intenção (se configurada)
-  const match = (configuredIntents || []).find((it:any)=> it.name===intent);
+  const match = (configuredIntents || []).find((it: any) => it.name === intent);
   let toolDirective = '';
   if (match?.tool) {
     const schema = match.tool_schema || null;
@@ -484,7 +744,8 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
   // Enriquecer com classificação visual da sessão (se houver)
   try {
     const vs = (session as any)?.state || {};
-    if (vs.visual_segment && !collected.segmento_visual) collected.segmento_visual = vs.visual_segment; // basico|inox|premium|indeterminado
+    if (vs.visual_segment && !collected.segmento_visual)
+      collected.segmento_visual = vs.visual_segment; // basico|inox|premium|indeterminado
     if (vs.visual_type && !collected.tipo_visual) collected.tipo_visual = vs.visual_type; // floor|cooktop|indeterminado
   } catch {}
 
@@ -500,30 +761,41 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
   console.log('[DEBUG] debug mode:', debug, 'env:', process.env.DEBUG_WEBHOOK);
 
   // Blocos relevantes para este turno
-  const relevant = findRelevantBlocks(allBlocks, body, { equipamento: collected.equipamento, problema: collected.problema, marca: collected.marca });
+  const relevant = findRelevantBlocks(allBlocks, body, {
+    equipamento: collected.equipamento,
+    problema: collected.problema,
+    marca: collected.marca,
+  });
   const knowledge = renderBlocksForPrompt(relevant);
   if (debug) console.log('[DEBUG] inbound', { from, body });
 
-
   // PRIORIDADE: Fallback determinístico para lava-louças ANTES do LLM
   const lower = (body || '').toLowerCase();
-  const isLavaLoucasKeyword = /(lava\s*-?lou[çc]a|lavalou|máquina\s+de\s+lavar\s+lou[çc]as|maquina\s+de\s+lavar\s+loucas)/i.test(lower);
+  const isLavaLoucasKeyword =
+    /(lava\s*-?lou[çc]a|lavalou|máquina\s+de\s+lavar\s+lou[çc]as|maquina\s+de\s+lavar\s+loucas)/i.test(
+      lower
+    );
   if (isLavaLoucasKeyword) {
     console.log('[DEBUG] LAVA-LOUÇAS detectado, forçando orçamento direto');
     try {
       const { buildQuote } = await import('./toolsRuntime.js');
-      const problemaText = lower.includes('não entra água') || lower.includes('nao entra agua') ? 'não entra água' : 'problema não especificado';
+      const problemaText =
+        lower.includes('não entra água') || lower.includes('nao entra agua')
+          ? 'não entra água'
+          : 'problema não especificado';
       const quote = await buildQuote({
         service_type: 'coleta_diagnostico',
         equipment: 'lava-louças',
         brand: 'Brastemp',
-        problem: problemaText
+        problem: problemaText,
       } as any);
       console.log('[DEBUG] LAVA-LOUÇAS quote result', quote);
       if (quote) {
         return await summarizeToolResult('orcamento', quote, session, body);
       }
-    } catch (e) { console.log('[DEBUG] LAVA-LOUÇAS fallback error', String(e)); }
+    } catch (e) {
+      console.log('[DEBUG] LAVA-LOUÇAS fallback error', String(e));
+    }
   }
 
   // Atualiza estado do funil com heurística leve
@@ -533,18 +805,24 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     const ai = await aiGuessFunnelFields(body);
     if (debug) console.log('[DEBUG] aiExtractor', ai);
     if (ai) {
-      const prev = ((session as any)?.state?.dados_coletados || {});
+      const prev = (session as any)?.state?.dados_coletados || {};
       const dadosAI = { ...prev } as any;
       if (ai.equipamento && !dadosAI.equipamento) dadosAI.equipamento = ai.equipamento;
       if (ai.marca && !dadosAI.marca) dadosAI.marca = ai.marca;
       if (ai.problema && !dadosAI.problema) dadosAI.problema = ai.problema;
       if (ai.mount && !dadosAI.mount) dadosAI.mount = ai.mount;
       if (ai.num_burners && !dadosAI.num_burners) dadosAI.num_burners = ai.num_burners;
-      if (ai.equipamentosEncontrados?.length) dadosAI.equipamentosEncontrados = ai.equipamentosEncontrados;
-      await setSessionState((session as any).id, { ...(session as any)?.state, dados_coletados: dadosAI });
+      if (ai.equipamentosEncontrados?.length)
+        dadosAI.equipamentosEncontrados = ai.equipamentosEncontrados;
+      await setSessionState((session as any).id, {
+        ...(session as any)?.state,
+        dados_coletados: dadosAI,
+      });
       if (debug) console.log('[DEBUG] afterAI state', (session as any)?.state?.dados_coletados);
     }
-  } catch (e) { if (debug) console.log('[DEBUG] aiExtractor error', String(e)); }
+  } catch (e) {
+    if (debug) console.log('[DEBUG] aiExtractor error', String(e));
+  }
 
   try {
     const g = guessFunnelFields(body);
@@ -564,7 +842,7 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
       }
     } catch {}
 
-    const prev = (prevAll?.dados_coletados || {});
+    const prev = prevAll?.dados_coletados || {};
     console.log('[DEBUG] dados anteriores da sessão:', prev);
     const dados = { ...prev } as any;
 
@@ -579,14 +857,26 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
         targetEquip = 'fogão a gás';
       }
 
-      console.log('[DEBUG] Detetado novo equipamento diferente:', targetEquip, '(anterior:', dados.equipamento, ')');
+      console.log(
+        '[DEBUG] Detetado novo equipamento diferente:',
+        targetEquip,
+        '(anterior:',
+        dados.equipamento,
+        ')'
+      );
       if (process.env.NODE_ENV === 'test') {
         // Em testes, aplicar troca imediatamente e resetar orçamento
         const stAll = (session as any)?.state || {};
         const newDados: any = { ...stAll.dados_coletados, equipamento: targetEquip };
         delete newDados.marca;
         delete newDados.problema;
-        const newState: any = { ...stAll, dados_coletados: newDados, orcamento_entregue: false, last_quote: null, last_quote_ts: null };
+        const newState: any = {
+          ...stAll,
+          dados_coletados: newDados,
+          orcamento_entregue: false,
+          last_quote: null,
+          last_quote_ts: null,
+        };
         try {
           if ((session as any)?.id) await setSessionState((session as any).id, newState);
           // Também atualiza objeto em memória para refletir imediatamente em testes
@@ -595,15 +885,23 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
         return `Perfeito, vamos continuar com ${targetEquip}. Qual é a marca?`;
       } else {
         // Em produção, solicitar confirmação ao usuário antes de trocar
-        try { if ((session as any)?.id) await setSessionState((session as any).id, { ...(session as any).state, pendingEquipmentSwitch: targetEquip }); } catch {}
+        try {
+          if ((session as any)?.id)
+            await setSessionState((session as any).id, {
+              ...(session as any).state,
+              pendingEquipmentSwitch: targetEquip,
+            });
+        } catch {}
         return `Entendi que você mencionou ${targetEquip}. Quer trocar o atendimento para esse equipamento? Responda SIM para trocar ou NÃO para manter ${dados.equipamento}.`;
       }
-
     } else if (g.equipamento && !dados.equipamento) {
       console.log('[DEBUG] Primeiro equipamento detectado:', g.equipamento);
       dados.equipamento = g.equipamento;
     } else {
-      console.log('[DEBUG] Nenhuma mudança de equipamento:', { detectado: g.equipamento, atual: dados.equipamento });
+      console.log('[DEBUG] Nenhuma mudança de equipamento:', {
+        detectado: g.equipamento,
+        atual: dados.equipamento,
+      });
     }
     if (g.marca && !dados.marca) dados.marca = g.marca;
     if (g.problema && !dados.problema) dados.problema = g.problema;
@@ -628,23 +926,41 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     // Regras de reforço baseadas na mensagem atual (não ambíguas)
     const msg = (body || '').toLowerCase();
     const ensurePrefer = (svc: string) => {
-      const arr = Array.from(new Set([svc, ...((chainDirectives.prefer_services)||[])]));
+      const arr = Array.from(new Set([svc, ...(chainDirectives.prefer_services || [])]));
       chainDirectives.prefer_services = arr;
     };
-    const msgSimple = msg.normalize('NFD').replace(/\p{Diacritic}/gu,'');
-    if ((msg.includes('fogão') || msgSimple.includes('fogao')) && (msg.includes('gás') || msgSimple.includes('gas'))) {
+    const msgSimple = msg.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+    if (
+      (msg.includes('fogão') || msgSimple.includes('fogao')) &&
+      (msg.includes('gás') || msgSimple.includes('gas'))
+    ) {
       ensurePrefer('domicilio');
       dados.equipamento = 'fogão a gás';
-    } else if ((msg.includes('fogão') || msgSimple.includes('fogao')) && (msg.includes('indução') || msgSimple.includes('inducao') || msg.includes('elétrico') || msgSimple.includes('eletrico'))) {
+    } else if (
+      (msg.includes('fogão') || msgSimple.includes('fogao')) &&
+      (msg.includes('indução') ||
+        msgSimple.includes('inducao') ||
+        msg.includes('elétrico') ||
+        msgSimple.includes('eletrico'))
+    ) {
       ensurePrefer('coleta_diagnostico');
-      dados.equipamento = msg.includes('indução') || msgSimple.includes('inducao') ? 'fogão de indução' : 'fogão elétrico';
+      dados.equipamento =
+        msg.includes('indução') || msgSimple.includes('inducao')
+          ? 'fogão de indução'
+          : 'fogão elétrico';
     }
     // Mapeamento explícito de "forno do fogão" vs "forno elétrico"
-    if (msg.includes('forno') && (msg.includes('fogão') || msgSimple.includes('fogao') || msg.includes('piso'))) {
+    if (
+      msg.includes('forno') &&
+      (msg.includes('fogão') || msgSimple.includes('fogao') || msg.includes('piso'))
+    ) {
       // Usuário está falando do forno do fogão de piso (a gás)
       ensurePrefer('domicilio');
       dados.equipamento = 'fogão a gás';
-    } else if (msg.includes('forno') && (msg.includes('elétrico') || msgSimple.includes('eletrico'))) {
+    } else if (
+      msg.includes('forno') &&
+      (msg.includes('elétrico') || msgSimple.includes('eletrico'))
+    ) {
       ensurePrefer('coleta_diagnostico');
       dados.equipamento = 'forno elétrico';
     } else if (msg.includes('forno') && msg.includes('embut')) {
@@ -656,7 +972,13 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     }
     // Complemento: se a mensagem atual trouxer apenas o tipo (ex.: "é a gás"),
     // mas já sabemos que o equipamento é um fogão, ajuste o tipo sem perguntar novamente
-    if (dados.equipamento && dados.equipamento.includes('fogão') && !dados.equipamento.includes('gás') && !dados.equipamento.includes('indução') && !dados.equipamento.includes('elétrico')) {
+    if (
+      dados.equipamento &&
+      dados.equipamento.includes('fogão') &&
+      !dados.equipamento.includes('gás') &&
+      !dados.equipamento.includes('indução') &&
+      !dados.equipamento.includes('elétrico')
+    ) {
       if (msg.includes('gás') || msg.includes('gas')) {
         ensurePrefer('domicilio');
         dados.equipamento = 'fogão a gás';
@@ -670,13 +992,22 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     }
     if ((msg.includes('micro-ondas') || msg.includes('microondas')) && msg.includes('embut')) {
       ensurePrefer('coleta_diagnostico');
-    } else if ((msg.includes('micro-ondas') || msg.includes('microondas')) && (msg.includes('bancada') || !msg.includes('embut'))) {
+    } else if (
+      (msg.includes('micro-ondas') || msg.includes('microondas')) &&
+      (msg.includes('bancada') || !msg.includes('embut'))
+    ) {
       ensurePrefer('coleta_conserto');
     }
-    if (msg.includes('lava lou') || msg.includes('lava-roup') || msg.includes('lava roupas') || msg.includes('lava e seca') || msg.includes('secadora')) {
+    if (
+      msg.includes('lava lou') ||
+      msg.includes('lava-roup') ||
+      msg.includes('lava roupas') ||
+      msg.includes('lava e seca') ||
+      msg.includes('secadora')
+    ) {
       ensurePrefer('coleta_diagnostico');
     }
-    const etapaAtual = ((session as any)?.state?.funil_etapa) || 'equipamento';
+    const etapaAtual = (session as any)?.state?.funil_etapa || 'equipamento';
 
     let proxima = etapaAtual;
     if (!dados.equipamento) proxima = 'equipamento';
@@ -688,21 +1019,37 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     const coletadoHuman = [
       dados.equipamento ? `equipamento: ${dados.equipamento}` : null,
       dados.marca ? `marca: ${dados.marca}` : null,
-      dados.problema ? `problema: ${dados.problema}` : null
-    ].filter(Boolean).join(' | ');
+      dados.problema ? `problema: ${dados.problema}` : null,
+    ]
+      .filter(Boolean)
+      .join(' | ');
     funnelText = `\n\nContexto do funil: já coletado -> ${coletadoHuman || 'nada'}. Próxima etapa: ${proxima}.\nRegra: NÃO repita perguntas de etapas já concluídas; avance diretamente para a próxima etapa indicada.`;
 
     // Persistir imediatamente mount/burners quando o usuário informar (evita loops)
     const prevState = (session as any)?.state || {};
     let stateChanged = false;
     const msgBody = (body || '').toLowerCase();
-    if (/\bpiso\b/.test(msgBody) && !prevState.visual_type) { prevState.visual_type = 'floor'; stateChanged = true; }
-    if (/\bcook ?top\b/.test(msgBody) && !prevState.visual_type) { prevState.visual_type = 'cooktop'; stateChanged = true; }
+    if (/\bpiso\b/.test(msgBody) && !prevState.visual_type) {
+      prevState.visual_type = 'floor';
+      stateChanged = true;
+    }
+    if (/\bcook ?top\b/.test(msgBody) && !prevState.visual_type) {
+      prevState.visual_type = 'cooktop';
+      stateChanged = true;
+    }
     const burnersMatch = msgBody.match(/(?:\b|^)(4|5|6)\s*bocas?\b/);
-    if (burnersMatch && !prevState.visual_burners) { prevState.visual_burners = burnersMatch[1]; stateChanged = true; }
+    if (burnersMatch && !prevState.visual_burners) {
+      prevState.visual_burners = burnersMatch[1];
+      stateChanged = true;
+    }
 
     if ((session as any)?.id) {
-      await setSessionState((session as any).id, { ...(session as any).state, ...(stateChanged ? prevState : {}), dados_coletados: dados, funil_etapa: proxima });
+      await setSessionState((session as any).id, {
+        ...(session as any).state,
+        ...(stateChanged ? prevState : {}),
+        dados_coletados: dados,
+        funil_etapa: proxima,
+      });
     }
   } catch {}
 
@@ -717,9 +1064,13 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
   const photoHint = (() => {
     try {
       const dados = (session as any)?.state?.dados_coletados || {};
-      const msg = (body||'').toLowerCase();
+      const msg = (body || '').toLowerCase();
       const isStoveGas = /fog[ãa]o/.test(msg) && /(g[áa]s|gas)/.test(msg);
-      const missingVisual = !(collected?.segmento_visual) || collected?.segmento_visual === 'indeterminado' || !(collected?.tipo_visual) || collected?.tipo_visual === 'indeterminado';
+      const missingVisual =
+        !collected?.segmento_visual ||
+        collected?.segmento_visual === 'indeterminado' ||
+        !collected?.tipo_visual ||
+        collected?.tipo_visual === 'indeterminado';
       if (isStoveGas && missingVisual) {
         return '\n- Se for caso de fogão a gás e ainda NÃO houver foto, peça UMA foto de frente (luz boa, pegando bocas e painel) de forma educada. Não insista se o cliente recusar ou ignorar. Use a foto apenas para estimar melhor o preço.';
       }
@@ -727,33 +1078,45 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     return '';
   })();
 
-  const sys = buildSystemPrompt((bot as any)?.personality?.systemPrompt, blocks) + '\n\n' + knowledge + '\n\n' + chainText + funnelText + '\n\n' + sensitiveGuard + '\n\n' + makeToolGuide() + toolDirective + '\n\n' +
-    'Quando for chamar uma ferramenta:'+
-    '\n- Prefira preencher client_name com o nome informado pelo usuário; se ausente, use o número do WhatsApp como fallback.'+
-    '\n- NUNCA peça telefone. Use automaticamente o número do WhatsApp; o executor preenche phone a partir do JID do contato.'+
-    '\n- Para orçamento, capte equipment (ex.: fogão, cooktop), brand/marca, problema/descrição e região/bairro quando o usuário mencionar.'+
-    '\n- Para agendamento, use a ferramenta aiScheduleStart quando tiver pelo menos nome, endereço e equipamento. Se o problema não estiver claro, use "problema não especificado". Depois que o cliente escolher 1/2/3, chame aiScheduleConfirm com opcao_escolhida.'+
-    '\n- Nunca invente dados: se faltar, pergunte de forma objetiva.'+
-    '\n- Evite frases como "vou solicitar orçamento"; se for usar ferramenta, responda apenas com JSON. Caso contrário, entregue o valor ou faça uma única pergunta objetiva.'+
-    '\n- Siga o funil: equipamento → marca → problema → causas possíveis (sem instruções de conserto) → oferta do serviço (definido pelas políticas do equipamento; não pergunte preferência).'+
-    '\n- IMPORTANTE: Não colete dados pessoais (nome, telefone, endereço, CPF) antes da aceitação explícita do orçamento.'+
-    '\n- CRUCIAL: Quando o cliente mencionar equipamentos ambíguos, SEMPRE pergunte para especificar ANTES de mostrar causas ou valores:'+
-    '\n  * "fogão" → pergunte: "É um fogão a gás, de indução ou elétrico?"'+
-    '\n  * "microondas" → pergunte: "É um microondas de bancada ou embutido?"'+
-    '\n  * "forno" → pergunte: "É um forno embutido, de bancada ou industrial?"'+
-    '\n- EQUIPAMENTOS INDUSTRIAIS: Atendemos fogões industriais (4-8 bocas), fornos industriais médio porte e geladeiras comerciais. NÃO atendemos fornos de esteira ou equipamentos de linha de produção.'+
-    '\n- NUNCA assuma o tipo do equipamento. SEMPRE pergunte primeiro.'+
-    '\n- Só ofereça causas técnicas e valores APÓS confirmar o tipo específico do equipamento.'+
-    '\n- REGRA DE SERVIÇOS (NUNCA pergunte preferência, decida automaticamente):'+
-    '\n  * Fogão a gás/cooktop → SEMPRE ofereça conserto em domicílio'+
-    '\n  * Fogão elétrico/indução → SEMPRE ofereça coleta para diagnóstico'+
-    '\n  * Fogão industrial/forno industrial/geladeira comercial → SEMPRE ofereça coleta para diagnóstico'+
-    '\n  * Microondas bancada → SEMPRE ofereça coleta para conserto'+
-    '\n  * Microondas embutido → SEMPRE ofereça coleta para diagnóstico'+
-    '\n  * Lava-louças/lava-roupas → SEMPRE ofereça coleta para diagnóstico'+
-    '\n- CRUCIAL: NUNCA revele ao cliente a classificação visual do fogão (básico/inox/premium ou similares). Use-a somente internamente para estimar preço.'+
-    '\n- IMPORTANTE: Para fogão a gás, SEMPRE chame buildQuote para mostrar o preço específico baseado no modelo/tipo. Não use apenas a mensagem genérica.'+
-    '\n- Quando identificar equipamento + problema, chame buildQuote imediatamente com service_type=\"domicilio\" (fogão a gás), equipment, brand, problem, etc.'+
+  const sys =
+    buildSystemPrompt((bot as any)?.personality?.systemPrompt, blocks) +
+    '\n\n' +
+    knowledge +
+    '\n\n' +
+    chainText +
+    funnelText +
+    '\n\n' +
+    sensitiveGuard +
+    '\n\n' +
+    makeToolGuide() +
+    toolDirective +
+    '\n\n' +
+    'Quando for chamar uma ferramenta:' +
+    '\n- Prefira preencher client_name com o nome informado pelo usuário; se ausente, use o número do WhatsApp como fallback.' +
+    '\n- NUNCA peça telefone. Use automaticamente o número do WhatsApp; o executor preenche phone a partir do JID do contato.' +
+    '\n- Para orçamento, capte equipment (ex.: fogão, cooktop), brand/marca, problema/descrição e região/bairro quando o usuário mencionar.' +
+    '\n- Para agendamento, use a ferramenta aiScheduleStart quando tiver pelo menos nome, endereço e equipamento. Se o problema não estiver claro, use "problema não especificado". Depois que o cliente escolher 1/2/3, chame aiScheduleConfirm com opcao_escolhida.' +
+    '\n- Nunca invente dados: se faltar, pergunte de forma objetiva.' +
+    '\n- Evite frases como "vou solicitar orçamento"; se for usar ferramenta, responda apenas com JSON. Caso contrário, entregue o valor ou faça uma única pergunta objetiva.' +
+    '\n- Siga o funil: equipamento → marca → problema → causas possíveis (sem instruções de conserto) → oferta do serviço (definido pelas políticas do equipamento; não pergunte preferência).' +
+    '\n- IMPORTANTE: Não colete dados pessoais (nome, telefone, endereço, CPF) antes da aceitação explícita do orçamento.' +
+    '\n- CRUCIAL: Quando o cliente mencionar equipamentos ambíguos, SEMPRE pergunte para especificar ANTES de mostrar causas ou valores:' +
+    '\n  * "fogão" → pergunte: "É um fogão a gás, de indução ou elétrico?"' +
+    '\n  * "microondas" → pergunte: "É um microondas de bancada ou embutido?"' +
+    '\n  * "forno" → pergunte: "É um forno embutido, de bancada ou industrial?"' +
+    '\n- EQUIPAMENTOS INDUSTRIAIS: Atendemos fogões industriais (4-8 bocas), fornos industriais médio porte e geladeiras comerciais. NÃO atendemos fornos de esteira ou equipamentos de linha de produção.' +
+    '\n- NUNCA assuma o tipo do equipamento. SEMPRE pergunte primeiro.' +
+    '\n- Só ofereça causas técnicas e valores APÓS confirmar o tipo específico do equipamento.' +
+    '\n- REGRA DE SERVIÇOS (NUNCA pergunte preferência, decida automaticamente):' +
+    '\n  * Fogão a gás/cooktop → SEMPRE ofereça conserto em domicílio' +
+    '\n  * Fogão elétrico/indução → SEMPRE ofereça coleta para diagnóstico' +
+    '\n  * Fogão industrial/forno industrial/geladeira comercial → SEMPRE ofereça coleta para diagnóstico' +
+    '\n  * Microondas bancada → SEMPRE ofereça coleta para conserto' +
+    '\n  * Microondas embutido → SEMPRE ofereça coleta para diagnóstico' +
+    '\n  * Lava-louças/lava-roupas → SEMPRE ofereça coleta para diagnóstico' +
+    '\n- CRUCIAL: NUNCA revele ao cliente a classificação visual do fogão (básico/inox/premium ou similares). Use-a somente internamente para estimar preço.' +
+    '\n- IMPORTANTE: Para fogão a gás, SEMPRE chame buildQuote para mostrar o preço específico baseado no modelo/tipo. Não use apenas a mensagem genérica.' +
+    '\n- Quando identificar equipamento + problema, chame buildQuote imediatamente com service_type=\"domicilio\" (fogão a gás), equipment, brand, problem, etc.' +
     photoHint;
   // Mensagem de oferta fixa baseada no serviço preferido
   let offerFixed = '';
@@ -761,9 +1124,12 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
   if (preferredService) {
     const msg = getOfferMessageForServiceType(policies, preferredService as any);
     if (msg) {
-      const serviceLabel = preferredService === 'domicilio' ? 'domicílio' :
-                          preferredService === 'coleta_diagnostico' ? 'coleta diagnóstico' :
-                          'coleta conserto';
+      const serviceLabel =
+        preferredService === 'domicilio'
+          ? 'domicílio'
+          : preferredService === 'coleta_diagnostico'
+            ? 'coleta diagnóstico'
+            : 'coleta conserto';
       offerFixed = `\n\nOferta (${serviceLabel}):\n${msg}`;
     }
   }
@@ -777,9 +1143,7 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     .order('created_at', { ascending: true })
     .limit(20); // últimas 20 mensagens
 
-  const messages: ChatMessage[] = [
-    { role: 'system', content: sys + offerFixed }
-  ];
+  const messages: ChatMessage[] = [{ role: 'system', content: sys + offerFixed }];
 
   // Adicionar histórico da conversa
   if (history && history.length > 0) {
@@ -798,22 +1162,30 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
   const llm = (bot as any)?.llm || {};
 
   const envForce = (process.env.LLM_FORCE_PROVIDER || '').toLowerCase();
-  const provider = (envForce === 'openai' || envForce === 'anthropic') ? envForce : (llm.provider || 'openai');
-  const model = provider === 'anthropic'
-    ? (llm.model || process.env.LLM_ANTHROPIC_MODEL || 'claude-3-5-sonnet-20241022')
-    : (llm.model || process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini');
+  const provider =
+    envForce === 'openai' || envForce === 'anthropic' ? envForce : llm.provider || 'openai';
+  const model =
+    provider === 'anthropic'
+      ? llm.model || process.env.LLM_ANTHROPIC_MODEL || 'claude-3-5-sonnet-20241022'
+      : llm.model || process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini';
   console.log('[LLM] Using provider/model:', provider, model);
-  let text = await chatComplete({
-    provider,
-    model,
-    temperature: llm.temperature ?? 0.7,
-    maxTokens: llm.maxTokens ?? 700
-  }, messages);
+  let text = await chatComplete(
+    {
+      provider,
+      model,
+      temperature: llm.temperature ?? 0.7,
+      maxTokens: llm.maxTokens ?? 700,
+    },
+    messages
+  );
 
   // Se o LLM responder com promessas vagas ("vou gerar e já retorno"), forçar cálculo imediato (evita ficar sem retorno)
   try {
     const t = String(text || '').toLowerCase();
-    const looksLikeDeferral = /((vou|irei)\s+(gerar|calcular|verificar|solicitar|pedir|pegar)\b.*(or[cç]amento|valor)?|\b(já|ja)\s+(retorno|volto|te\s+retorno|te\s+passo|trago\s+o\s+valor)|\bem\s+instantes\b|\bem\s+breve\b|\bdaqui\s+a\s+pouco\b)/.test(t);
+    const looksLikeDeferral =
+      /((vou|irei)\s+(gerar|calcular|verificar|solicitar|pedir|pegar)\b.*(or[cç]amento|valor)?|\b(já|ja)\s+(retorno|volto|te\s+retorno|te\s+passo|trago\s+o\s+valor)|\bem\s+instantes\b|\bem\s+breve\b|\bdaqui\s+a\s+pouco\b)/.test(
+        t
+      );
     if (looksLikeDeferral) text = '';
   } catch {}
 
@@ -821,14 +1193,12 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
   const { tryExecuteTool } = await import('./toolExecutor.js');
   const result = await tryExecuteTool(text || '', { channel: 'whatsapp', peer: from });
   if (result) {
-  if (debug) console.log('[DEBUG] llmText', String(text||'').slice(0,240));
-  if (debug) console.log('[DEBUG] toolResult', result);
+    if (debug) console.log('[DEBUG] llmText', String(text || '').slice(0, 240));
+    if (debug) console.log('[DEBUG] toolResult', result);
 
     // sintetiza uma resposta curta ao usuário baseada no resultado
     return await summarizeToolResult(intent, result, session, body);
   }
-
-
 
   // Fallback determinístico: se houver indícios de fogão e dados suficientes, chama buildQuote automaticamente
   try {
@@ -844,10 +1214,13 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     const vs = (session as any)?.state || {};
     const hasVisual = !!(vs?.visual_type && vs.visual_type !== 'indeterminado');
     const mentionsStove = /fog[ãa]o/.test(lower);
-    const collectedStove = typeof collected?.equipamento === 'string' && /(fog[ãa]o)/.test((collected.equipamento||'').toLowerCase());
+    const collectedStove =
+      typeof collected?.equipamento === 'string' &&
+      /(fog[ãa]o)/.test((collected.equipamento || '').toLowerCase());
     const mentionsMountOnly = /(\bpiso\b|\bcook ?top\b)/.test(lower);
     const mentionsBurners = /(?:\b|^)(4|5|6)\s*bocas?\b/.test(lower);
-    const isStoveContext = mentionsStove || collectedStove || hasVisual || mentionsMountOnly || mentionsBurners;
+    const isStoveContext =
+      mentionsStove || collectedStove || hasVisual || mentionsMountOnly || mentionsBurners;
 
     // Problema: usa da mensagem atual, ou do histórico recente, ou do coletado
     let problem = g?.problema || collected?.problema || undefined;
@@ -856,7 +1229,10 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
         const msg = history[i];
         if (msg.direction === 'in') {
           const gg = guessFunnelFields(msg.body || '');
-          if (gg?.problema) { problem = gg.problema; break; }
+          if (gg?.problema) {
+            problem = gg.problema;
+            break;
+          }
         }
       }
     }
@@ -864,15 +1240,21 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
     if (isStoveContext && problem) {
       const { buildQuote } = await import('./toolsRuntime.js');
       let mount = hasVisual ? (vs.visual_type === 'floor' ? 'piso' : 'cooktop') : undefined;
-      const segment = vs?.visual_segment && vs.visual_segment !== 'indeterminado' ? vs.visual_segment : undefined;
+      const segment =
+        vs?.visual_segment && vs.visual_segment !== 'indeterminado' ? vs.visual_segment : undefined;
 
       // Heurística textual: buscar "piso" ou "cooktop" no histórico da conversa
       if (!mount && history && history.length > 0) {
         for (const msg of history) {
           if (msg.direction === 'in') {
             const mtxt = (msg.body || '').toLowerCase();
-            if (/\bpiso\b/.test(mtxt)) { mount = 'piso'; break; }
-            else if (/\bcook ?top\b/.test(mtxt)) { mount = 'cooktop'; break; }
+            if (/\bpiso\b/.test(mtxt)) {
+              mount = 'piso';
+              break;
+            } else if (/\bcook ?top\b/.test(mtxt)) {
+              mount = 'cooktop';
+              break;
+            }
           }
         }
       }
@@ -884,13 +1266,19 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
       }
 
       // Buscar número de bocas: primeiro a classificação visual, depois histórico e mensagem
-      let burners = (vs?.visual_burners && vs.visual_burners !== 'indeterminado') ? vs.visual_burners : (g as any)?.num_burners;
+      let burners =
+        vs?.visual_burners && vs.visual_burners !== 'indeterminado'
+          ? vs.visual_burners
+          : (g as any)?.num_burners;
       if (!burners && history && history.length > 0) {
         for (const msg of history) {
           if (msg.direction === 'in') {
             const mtxt = (msg.body || '').toLowerCase();
             const m = mtxt.match(/(?:\b|^)(4|5|6)\s*bocas?\b/);
-            if (m) { burners = m[1]; break; }
+            if (m) {
+              burners = m[1];
+              break;
+            }
           }
         }
       }
@@ -905,12 +1293,18 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
         const prevState = (session as any)?.state || {};
         const now = Date.now();
         const cooldownMs = 60_000; // 60s
-        const askedMountRecently = prevState.lastAskMountAt && (now - prevState.lastAskMountAt < cooldownMs);
-        const askedBurnersRecently = prevState.lastAskBurnersAt && (now - prevState.lastAskBurnersAt < cooldownMs);
+        const askedMountRecently =
+          prevState.lastAskMountAt && now - prevState.lastAskMountAt < cooldownMs;
+        const askedBurnersRecently =
+          prevState.lastAskBurnersAt && now - prevState.lastAskBurnersAt < cooldownMs;
 
         if (!mount && !burners) {
           if (!askedMountRecently || !askedBurnersRecently) {
-            await setSessionState((session as any).id, { ...prevState, lastAskMountAt: now, lastAskBurnersAt: now });
+            await setSessionState((session as any).id, {
+              ...prevState,
+              lastAskMountAt: now,
+              lastAskBurnersAt: now,
+            });
             return 'Para te passar o valor certinho, me diga: é fogão de piso ou cooktop? E ele é de 4, 5 ou 6 bocas?';
           }
           return null;
@@ -940,7 +1334,7 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
         problem,
         mount,
         segment,
-        num_burners: burners
+        num_burners: burners,
       } as any);
 
       if (quote) {
@@ -948,199 +1342,403 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
       }
     }
 
-  // Fallback determinístico: outros equipamentos (lava-louça, lavadora, micro-ondas, coifa, secadora)
-  try {
-    const lower = (body || '').toLowerCase();
-    const g = guessFunnelFields(body);
-    const collected = (session as any)?.state?.dados_coletados || {};
-    const equipamento = (g?.equipamentosEncontrados?.[0] || collected?.equipamento || '').toLowerCase();
-    const marca = g?.marca || collected?.marca || undefined;
-    const problema = g?.problema || collected?.problema || undefined;
-
-    const isLavalouca = /(lava\s*-?lou[çc]a|lavalou[cç]a|lava\s*-?lou[cs]as)/i.test(equipamento);
-    const isLavadora = /(lava\s*-?roupa|lavadora|m[aá]quina\s+de\s+lavar)/i.test(equipamento);
-    const isMicro = /(micro[- ]?ondas|microondas)/i.test(equipamento);
-    const isCoifa = /coifa|depurador|exaustor/.test(equipamento);
-    const isLavaLoucasKeyword = /(lava\s*-?lou[çc]a|lavalou|máquina\s+de\s+lavar\s+lou[çc]as|maquina\s+de\s+lavar\s+loucas)/i.test(lower);
-
-
-
-
-
-    // Política: se o texto sugerir domicílio mas as políticas preferem coleta, corrige chamando buildQuote
+    // Fallback determinístico: outros equipamentos (lava-louça, lavadora, micro-ondas, coifa, secadora)
     try {
-      const tLower = (text || '').toLowerCase();
-      const suggestsDomicilio = /domic[íi]lio/.test(tLower);
-      const g2 = guessFunnelFields(body);
-      const collected2 = (session as any)?.state?.dados_coletados || {};
-      const eq2 = (g2?.equipamentosEncontrados?.[0] || collected2?.equipamento || '').toLowerCase();
-      const prefer = getPreferredServicesForEquipment(policies, eq2);
-      if (suggestsDomicilio && prefer.length && !prefer.includes('domicilio')) {
-        const { buildQuote } = await import('./toolsRuntime.js');
-        const st = prefer[0];
-        const marca2 = g2?.marca || collected2?.marca || undefined;
-        const problema2 = g2?.problema || collected2?.problema || undefined;
-        const label = /micro/.test(eq2) ? 'micro-ondas'
-          : /(lava\s*-?lou[çc]a|lavalou)/.test(eq2) ? 'lava-louças'
-          : /(lava\s*-?roupa|lavadora|m[aá]quina\s+de\s+lavar)/.test(eq2) ? 'lavadora'
-          : /coifa|depurador|exaustor/.test(eq2) ? 'coifa'
-          : /secadora/.test(eq2) ? 'secadora'
-          : eq2 || 'equipamento';
-        // 🔧 CORREÇÃO: Não assumir que tudo com "bancada" é micro-ondas
-        const mount2 = /micro/.test(eq2) && !/(forno.*industrial|industrial.*forno)/.test(body.toLowerCase())
-          ? (/(embut)/.test(body.toLowerCase()) ? 'embutido' : 'bancada')
-          : /(forno.*industrial|industrial.*forno)/.test(body.toLowerCase()) ? 'industrial' : undefined;
-        const quote2 = await buildQuote({ service_type: st, equipment: label, brand: marca2, problem: problema2, mount: mount2 } as any);
-        if (quote2) {
-          return await summarizeToolResult('orcamento', quote2, session, body);
+      const lower = (body || '').toLowerCase();
+      const g = guessFunnelFields(body);
+      const collected = (session as any)?.state?.dados_coletados || {};
+      const equipamento = (
+        g?.equipamentosEncontrados?.[0] ||
+        collected?.equipamento ||
+        ''
+      ).toLowerCase();
+      const marca = g?.marca || collected?.marca || undefined;
+      const problema = g?.problema || collected?.problema || undefined;
+
+      const isLavalouca = /(lava\s*-?lou[çc]a|lavalou[cç]a|lava\s*-?lou[cs]as)/i.test(equipamento);
+      const isLavadora = /(lava\s*-?roupa|lavadora|m[aá]quina\s+de\s+lavar)/i.test(equipamento);
+      const isMicro = /(micro[- ]?ondas|microondas)/i.test(equipamento);
+      const isCoifa = /coifa|depurador|exaustor/.test(equipamento);
+      const isLavaLoucasKeyword =
+        /(lava\s*-?lou[çc]a|lavalou|máquina\s+de\s+lavar\s+lou[çc]as|maquina\s+de\s+lavar\s+loucas)/i.test(
+          lower
+        );
+
+      // Política: se o texto sugerir domicílio mas as políticas preferem coleta, corrige chamando buildQuote
+      try {
+        const tLower = (text || '').toLowerCase();
+        const suggestsDomicilio = /domic[íi]lio/.test(tLower);
+        const g2 = guessFunnelFields(body);
+        const collected2 = (session as any)?.state?.dados_coletados || {};
+        const eq2 = (
+          g2?.equipamentosEncontrados?.[0] ||
+          collected2?.equipamento ||
+          ''
+        ).toLowerCase();
+        const prefer = getPreferredServicesForEquipment(policies, eq2);
+        if (suggestsDomicilio && prefer.length && !prefer.includes('domicilio')) {
+          const { buildQuote } = await import('./toolsRuntime.js');
+          const st = prefer[0];
+          const marca2 = g2?.marca || collected2?.marca || undefined;
+          const problema2 = g2?.problema || collected2?.problema || undefined;
+          const label = /micro/.test(eq2)
+            ? 'micro-ondas'
+            : /(lava\s*-?lou[çc]a|lavalou)/.test(eq2)
+              ? 'lava-louças'
+              : /(lava\s*-?roupa|lavadora|m[aá]quina\s+de\s+lavar)/.test(eq2)
+                ? 'lavadora'
+                : /coifa|depurador|exaustor/.test(eq2)
+                  ? 'coifa'
+                  : /secadora/.test(eq2)
+                    ? 'secadora'
+                    : eq2 || 'equipamento';
+          // 🔧 CORREÇÃO: Não assumir que tudo com "bancada" é micro-ondas
+          const mount2 =
+            /micro/.test(eq2) && !/(forno.*industrial|industrial.*forno)/.test(body.toLowerCase())
+              ? /(embut)/.test(body.toLowerCase())
+                ? 'embutido'
+                : 'bancada'
+              : /(forno.*industrial|industrial.*forno)/.test(body.toLowerCase())
+                ? 'industrial'
+                : undefined;
+          const quote2 = await buildQuote({
+            service_type: st,
+            equipment: label,
+            brand: marca2,
+            problem: problema2,
+            mount: mount2,
+          } as any);
+          if (quote2) {
+            return await summarizeToolResult('orcamento', quote2, session, body);
+          }
         }
-      }
-    } catch {}
+      } catch {}
 
-    const isSecadora = /secadora/.test(equipamento);
-    const isGeladeira = /(geladeira|refrigerador|freezer)/i.test(equipamento);
-    const isAdega = /(adega)/i.test(equipamento);
-    const isForno = /(forno)/i.test(equipamento);
+      const isSecadora = /secadora/.test(equipamento);
+      const isGeladeira = /(geladeira|refrigerador|freezer)/i.test(equipamento);
+      const isAdega = /(adega)/i.test(equipamento);
+      const isForno = /(forno)/i.test(equipamento);
 
-    // 🏭 USAR A DETECÇÃO DE EQUIPAMENTOS INDUSTRIAIS
-    const isIndustrialAtendemos = /(fog[aã]o\s*industrial|forno\s*industrial|industrial.*(?:4|5|6|8)\s*bocas?)/i.test(lower)
-      || /(geladeira\s*comercial|refrigerador\s*comercial)/i.test(lower)
-      || /(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno|forno.*m[eé]dio.*porte|m[eé]dio.*porte.*forno)/i.test(lower);
+      // 🏭 USAR A DETECÇÃO DE EQUIPAMENTOS INDUSTRIAIS
+      const isIndustrialAtendemos =
+        /(fog[aã]o\s*industrial|forno\s*industrial|industrial.*(?:4|5|6|8)\s*bocas?)/i.test(
+          lower
+        ) ||
+        /(geladeira\s*comercial|refrigerador\s*comercial)/i.test(lower) ||
+        /(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno|forno.*m[eé]dio.*porte|m[eé]dio.*porte.*forno)/i.test(
+          lower
+        );
 
-    if ((isLavalouca || isLavadora || isMicro || isCoifa || isSecadora || isGeladeira || isAdega || isForno || isIndustrialAtendemos || isLavaLoucasKeyword)) {
-      const { buildQuote } = await import('./toolsRuntime.js');
+      if (
+        isLavalouca ||
+        isLavadora ||
+        isMicro ||
+        isCoifa ||
+        isSecadora ||
+        isGeladeira ||
+        isAdega ||
+        isForno ||
+        isIndustrialAtendemos ||
+        isLavaLoucasKeyword
+      ) {
+        const { buildQuote } = await import('./toolsRuntime.js');
 
-      // 🏭 LÓGICA ESPECÍFICA PARA EQUIPAMENTOS INDUSTRIAIS QUE ATENDEMOS
-      if (isIndustrialAtendemos) {
-        const service_type = 'coleta_diagnostico'; // Equipamentos comerciais sempre coleta
-        const equipmentLabel = /(fogão industrial)/i.test(lower) ? 'fogão industrial'
-          : /(forno industrial)/i.test(lower) ? 'forno industrial'
-          : /(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno|forno.*médio.*porte|médio.*porte.*forno)/i.test(lower) ? 'forno comercial'
-          : /(geladeira comercial|refrigerador comercial)/i.test(lower) ? 'geladeira comercial'
-          : 'equipamento comercial';
-        const mount = 'industrial';
-        const is_industrial = true;
+        // 🏭 LÓGICA ESPECÍFICA PARA EQUIPAMENTOS INDUSTRIAIS QUE ATENDEMOS
+        if (isIndustrialAtendemos) {
+          const service_type = 'coleta_diagnostico'; // Equipamentos comerciais sempre coleta
+          const equipmentLabel = /(fogão industrial)/i.test(lower)
+            ? 'fogão industrial'
+            : /(forno industrial)/i.test(lower)
+              ? 'forno industrial'
+              : /(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno|forno.*médio.*porte|médio.*porte.*forno)/i.test(
+                    lower
+                  )
+                ? 'forno comercial'
+                : /(geladeira comercial|refrigerador comercial)/i.test(lower)
+                  ? 'geladeira comercial'
+                  : 'equipamento comercial';
+          const mount = 'industrial';
+          const is_industrial = true;
+
+          const quote = await buildQuote({
+            service_type,
+            equipment: equipmentLabel,
+            brand: marca,
+            problem: problema,
+            mount,
+            is_industrial,
+          } as any);
+
+          if (quote) {
+            // Injetar causas específicas para comerciais/industriais, garantindo prefixo antes da coleta
+            try {
+              const probLower = String(problema || body || '').toLowerCase();
+              let causas: string[] = [];
+              if (equipmentLabel === 'forno comercial' || equipmentLabel === 'forno industrial') {
+                causas = /não esquenta|nao esquenta|nao aquece|não aquece/.test(probLower)
+                  ? [
+                      'Resistências queimadas',
+                      'Termostato defeituoso',
+                      'Controlador/placa',
+                      'Relé de potência',
+                      'Sensor de temperatura',
+                    ]
+                  : /não liga|nao liga/.test(probLower)
+                    ? [
+                        'Alimentação elétrica',
+                        'Fusível queimado',
+                        'Chave seletora',
+                        'Placa de controle',
+                      ]
+                    : [
+                        'Sistema de aquecimento',
+                        'Sensor de temperatura',
+                        'Termostato',
+                        'Placa eletrônica',
+                      ];
+              } else if (equipmentLabel === 'fogão industrial') {
+                causas = /não acende|nao acende|sem chama|chama apaga/.test(probLower)
+                  ? [
+                      'Queimadores sujos/obstruídos',
+                      'Injetor entupido',
+                      'Sistema de ignição/acendedor',
+                      'Válvula/registro',
+                      'Regulagem de ar insuficiente',
+                    ]
+                  : /vazamento|vaza/.test(probLower)
+                    ? ['Mangueira danificada', 'Conexões frouxas', 'Registro com defeito']
+                    : /chama amarela|chama fraca/.test(probLower)
+                      ? [
+                          'Mistura ar/gás desregulada',
+                          'Injetor inadequado',
+                          'Entrada de ar obstruída',
+                        ]
+                      : ['Queimadores', 'Injetor', 'Sistema de ignição', 'Válvulas/registro'];
+              }
+              if (causas.length) {
+                (quote as any).causas_possiveis = causas;
+              }
+            } catch {}
+
+            return await summarizeToolResult('orcamento', quote, session, body);
+          }
+        }
+
+        // Políticas típicas: coleta diagnóstico para estes equipamentos
+        const service_type =
+          isMicro &&
+          lower.includes('bancada') &&
+          !/(forno.*industrial|industrial.*forno)/.test(lower)
+            ? 'coleta_conserto'
+            : 'coleta_diagnostico';
+        const mount =
+          isMicro && !/(forno.*industrial|industrial.*forno)/.test(lower)
+            ? lower.includes('embut')
+              ? 'embutido'
+              : 'bancada'
+            : undefined;
+        const equipmentLabel = isLavalouca
+          ? 'lava-louças'
+          : isLavadora
+            ? 'lavadora'
+            : isMicro && !/(forno.*industrial|industrial.*forno)/.test(lower)
+              ? 'micro-ondas'
+              : isCoifa
+                ? 'coifa'
+                : isGeladeira
+                  ? 'geladeira'
+                  : isAdega
+                    ? 'adega'
+                    : isForno
+                      ? 'forno'
+                      : 'secadora';
+        const problemaText =
+          problema ||
+          (lower.includes('não entra água') || lower.includes('nao entra agua')
+            ? 'não entra água'
+            : g?.problema || 'problema não especificado');
+
+        // Causas específicas por equipamento
+        let causasEspecificas: string[] = [];
+        if (isLavalouca) {
+          causasEspecificas =
+            problemaText.includes('não entra água') || problemaText.includes('nao entra agua')
+              ? [
+                  'Válvula de entrada entupida',
+                  'Filtro de entrada obstruído',
+                  'Problema na bomba de água',
+                  'Sensor de nível defeituoso',
+                ]
+              : [
+                  'Problema no sistema de drenagem',
+                  'Filtro entupido',
+                  'Bomba de circulação defeituosa',
+                  'Sensor de temperatura',
+                ];
+        } else if (isLavadora) {
+          causasEspecificas =
+            problemaText.includes('não entra água') || problemaText.includes('nao entra agua')
+              ? [
+                  'Válvula de entrada defeituosa',
+                  'Mangueira de entrada entupida',
+                  'Filtro de entrada obstruído',
+                  'Pressostato com problema',
+                ]
+              : problemaText.includes('não centrifuga') || problemaText.includes('nao centrifuga')
+                ? [
+                    'Motor da lavadora defeituoso',
+                    'Correia do motor',
+                    'Placa eletrônica',
+                    'Sensor de desequilíbrio',
+                  ]
+                : problemaText.includes('não liga') || problemaText.includes('nao liga')
+                  ? [
+                      'Problema na fonte de alimentação',
+                      'Placa eletrônica defeituosa',
+                      'Trava da porta',
+                      'Filtro de linha',
+                    ]
+                  : [
+                      'Motor da bomba de drenagem',
+                      'Filtro da bomba entupido',
+                      'Mangueira de saída obstruída',
+                      'Sensor de nível',
+                    ];
+        } else if (isMicro) {
+          causasEspecificas = [
+            'Magnetron queimado',
+            'Fusível de alta tensão',
+            'Diodo de alta tensão',
+            'Capacitor defeituoso',
+          ];
+        } else if (isCoifa) {
+          causasEspecificas = [
+            'Motor do exaustor defeituoso',
+            'Filtro de gordura saturado',
+            'Problema na fiação elétrica',
+            'Turbina danificada',
+          ];
+        } else if (isSecadora) {
+          causasEspecificas = [
+            'Resistência queimada',
+            'Termostato defeituoso',
+            'Motor do tambor',
+            'Sensor de temperatura',
+          ];
+        } else if (isGeladeira) {
+          causasEspecificas =
+            problemaText.includes('não gela') || problemaText.includes('nao gela')
+              ? [
+                  'Gás refrigerante insuficiente',
+                  'Compressor defeituoso',
+                  'Termostato com problema',
+                  'Evaporador obstruído',
+                ]
+              : problemaText.includes('não liga') || problemaText.includes('nao liga')
+                ? [
+                    'Problema na fonte de alimentação',
+                    'Compressor queimado',
+                    'Relé do compressor',
+                    'Termostato defeituoso',
+                  ]
+                : problemaText.includes('vazando') || problemaText.includes('vaza')
+                  ? [
+                      'Vedação da porta ressecada',
+                      'Dreno entupido',
+                      'Mangueira furada',
+                      'Evaporador com gelo excessivo',
+                    ]
+                  : [
+                      'Sistema de refrigeração',
+                      'Sensor de temperatura',
+                      'Ventilador interno',
+                      'Placa eletrônica',
+                    ];
+        } else if (isAdega) {
+          causasEspecificas = /não gela|nao gela|parou de esfriar|não esfria|nao esfria/i.test(
+            problemaText
+          )
+            ? [
+                'Ventilador do evaporador defeituoso',
+                'Condensador sujo',
+                'Gás refrigerante insuficiente',
+                'Compressor com falha',
+                'Sensor/termostato (NTC)',
+                'Placa eletrônica',
+                'Vedação da porta danificada',
+              ]
+            : /não liga|nao liga/i.test(problemaText)
+              ? [
+                  'Alimentação elétrica/fusível',
+                  'Placa eletrônica',
+                  'Termostato de segurança',
+                  'Chave/interruptor',
+                ]
+              : [
+                  'Sistema de refrigeração',
+                  'Sensor de temperatura (NTC)',
+                  'Ventilador interno',
+                  'Placa eletrônica',
+                ];
+        } else if (isForno) {
+          causasEspecificas =
+            problemaText.includes('não esquenta') || problemaText.includes('nao esquenta')
+              ? [
+                  'Resistência queimada',
+                  'Termostato defeituoso',
+                  'Sensor de temperatura',
+                  'Placa eletrônica',
+                ]
+              : problemaText.includes('não liga') || problemaText.includes('nao liga')
+                ? [
+                    'Problema na alimentação elétrica',
+                    'Trava da porta',
+                    'Fusível queimado',
+                    'Placa de controle',
+                  ]
+                : [
+                    'Sistema de aquecimento',
+                    'Ventilador interno',
+                    'Sensor de temperatura',
+                    'Termostato',
+                  ];
+        }
+
+        if (debug)
+          console.log('[DEBUG] buildQuote payload', {
+            service_type,
+            equipment: equipmentLabel,
+            brand: marca,
+            problem: problemaText,
+            mount,
+          });
 
         const quote = await buildQuote({
           service_type,
           equipment: equipmentLabel,
           brand: marca,
-          problem: problema,
+          problem: problemaText,
           mount,
-          is_industrial
         } as any);
 
+        if (debug) console.log('[DEBUG] buildQuote result', quote);
         if (quote) {
-          // Injetar causas específicas para comerciais/industriais, garantindo prefixo antes da coleta
-          try {
-            const probLower = String(problema || body || '').toLowerCase();
-            let causas: string[] = [];
-            if (equipmentLabel === 'forno comercial' || equipmentLabel === 'forno industrial') {
-              causas = (/não esquenta|nao esquenta|nao aquece|não aquece/.test(probLower)
-                ? ['Resistências queimadas','Termostato defeituoso','Controlador/placa','Relé de potência','Sensor de temperatura']
-                : /não liga|nao liga/.test(probLower)
-                ? ['Alimentação elétrica','Fusível queimado','Chave seletora','Placa de controle']
-                : ['Sistema de aquecimento','Sensor de temperatura','Termostato','Placa eletrônica']);
-            } else if (equipmentLabel === 'fogão industrial') {
-              causas = (/não acende|nao acende|sem chama|chama apaga/.test(probLower)
-                ? ['Queimadores sujos/obstruídos','Injetor entupido','Sistema de ignição/acendedor','Válvula/registro','Regulagem de ar insuficiente']
-                : /vazamento|vaza/.test(probLower)
-                ? ['Mangueira danificada','Conexões frouxas','Registro com defeito']
-                : /chama amarela|chama fraca/.test(probLower)
-                ? ['Mistura ar/gás desregulada','Injetor inadequado','Entrada de ar obstruída']
-                : ['Queimadores','Injetor','Sistema de ignição','Válvulas/registro']);
-            }
-            if (causas.length) {
-              (quote as any).causas_possiveis = causas;
-            }
-          } catch {}
-
+          // Adicionar causas específicas ao resultado
+          if (causasEspecificas.length > 0) {
+            quote.causas_possiveis = causasEspecificas;
+          }
           return await summarizeToolResult('orcamento', quote, session, body);
         }
       }
-
-      // Políticas típicas: coleta diagnóstico para estes equipamentos
-      const service_type = (isMicro && lower.includes('bancada') && !/(forno.*industrial|industrial.*forno)/.test(lower)) ? 'coleta_conserto' : 'coleta_diagnostico';
-      const mount = isMicro && !/(forno.*industrial|industrial.*forno)/.test(lower) ? (lower.includes('embut') ? 'embutido' : 'bancada') : undefined;
-      const equipmentLabel = isLavalouca ? 'lava-louças'
-        : isLavadora ? 'lavadora'
-        : isMicro && !/(forno.*industrial|industrial.*forno)/.test(lower) ? 'micro-ondas'
-        : isCoifa ? 'coifa'
-        : isGeladeira ? 'geladeira'
-        : isAdega ? 'adega'
-        : isForno ? 'forno'
-        : 'secadora';
-      const problemaText = problema || (lower.includes('não entra água') || lower.includes('nao entra agua') ? 'não entra água' : (g?.problema || 'problema não especificado'));
-
-      // Causas específicas por equipamento
-      let causasEspecificas: string[] = [];
-      if (isLavalouca) {
-        causasEspecificas = problemaText.includes('não entra água') || problemaText.includes('nao entra agua')
-          ? ['Válvula de entrada entupida', 'Filtro de entrada obstruído', 'Problema na bomba de água', 'Sensor de nível defeituoso']
-          : ['Problema no sistema de drenagem', 'Filtro entupido', 'Bomba de circulação defeituosa', 'Sensor de temperatura'];
-      } else if (isLavadora) {
-        causasEspecificas = problemaText.includes('não entra água') || problemaText.includes('nao entra agua')
-          ? ['Válvula de entrada defeituosa', 'Mangueira de entrada entupida', 'Filtro de entrada obstruído', 'Pressostato com problema']
-          : problemaText.includes('não centrifuga') || problemaText.includes('nao centrifuga')
-          ? ['Motor da lavadora defeituoso', 'Correia do motor', 'Placa eletrônica', 'Sensor de desequilíbrio']
-          : problemaText.includes('não liga') || problemaText.includes('nao liga')
-          ? ['Problema na fonte de alimentação', 'Placa eletrônica defeituosa', 'Trava da porta', 'Filtro de linha']
-          : ['Motor da bomba de drenagem', 'Filtro da bomba entupido', 'Mangueira de saída obstruída', 'Sensor de nível'];
-      } else if (isMicro) {
-        causasEspecificas = ['Magnetron queimado', 'Fusível de alta tensão', 'Diodo de alta tensão', 'Capacitor defeituoso'];
-      } else if (isCoifa) {
-        causasEspecificas = ['Motor do exaustor defeituoso', 'Filtro de gordura saturado', 'Problema na fiação elétrica', 'Turbina danificada'];
-      } else if (isSecadora) {
-        causasEspecificas = ['Resistência queimada', 'Termostato defeituoso', 'Motor do tambor', 'Sensor de temperatura'];
-      } else if (isGeladeira) {
-        causasEspecificas = problemaText.includes('não gela') || problemaText.includes('nao gela')
-          ? ['Gás refrigerante insuficiente', 'Compressor defeituoso', 'Termostato com problema', 'Evaporador obstruído']
-          : problemaText.includes('não liga') || problemaText.includes('nao liga')
-          ? ['Problema na fonte de alimentação', 'Compressor queimado', 'Relé do compressor', 'Termostato defeituoso']
-          : problemaText.includes('vazando') || problemaText.includes('vaza')
-          ? ['Vedação da porta ressecada', 'Dreno entupido', 'Mangueira furada', 'Evaporador com gelo excessivo']
-          : ['Sistema de refrigeração', 'Sensor de temperatura', 'Ventilador interno', 'Placa eletrônica'];
-      } else if (isAdega) {
-        causasEspecificas = /não gela|nao gela|parou de esfriar|não esfria|nao esfria/i.test(problemaText)
-          ? ['Ventilador do evaporador defeituoso','Condensador sujo','Gás refrigerante insuficiente','Compressor com falha','Sensor/termostato (NTC)','Placa eletrônica','Vedação da porta danificada']
-          : /não liga|nao liga/i.test(problemaText)
-          ? ['Alimentação elétrica/fusível','Placa eletrônica','Termostato de segurança','Chave/interruptor']
-          : ['Sistema de refrigeração','Sensor de temperatura (NTC)','Ventilador interno','Placa eletrônica'];
-      } else if (isForno) {
-        causasEspecificas = problemaText.includes('não esquenta') || problemaText.includes('nao esquenta')
-          ? ['Resistência queimada', 'Termostato defeituoso', 'Sensor de temperatura', 'Placa eletrônica']
-          : problemaText.includes('não liga') || problemaText.includes('nao liga')
-          ? ['Problema na alimentação elétrica', 'Trava da porta', 'Fusível queimado', 'Placa de controle']
-          : ['Sistema de aquecimento', 'Ventilador interno', 'Sensor de temperatura', 'Termostato'];
-      }
-
-      if (debug) console.log('[DEBUG] buildQuote payload', { service_type, equipment: equipmentLabel, brand: marca, problem: problemaText, mount });
-
-
-      const quote = await buildQuote({
-        service_type,
-        equipment: equipmentLabel,
-        brand: marca,
-        problem: problemaText,
-        mount
-      } as any);
-
-      if (debug) console.log('[DEBUG] buildQuote result', quote);
-      if (quote) {
-        // Adicionar causas específicas ao resultado
-        if (causasEspecificas.length > 0) {
-          quote.causas_possiveis = causasEspecificas;
-        }
-        return await summarizeToolResult('orcamento', quote, session, body);
-      }
+    } catch (e) {
+      if (debug) console.log('[DEBUG] deterministic fallback error', String(e));
     }
-  } catch (e) { if (debug) console.log('[DEBUG] deterministic fallback error', String(e)); }
-
   } catch {}
 
   // Se o LLM respondeu mas não incluiu causas, anexar fallback (quando aplicável)
   if (text && typeof text === 'string') {
-    const hasCausas = /poss[ií]veis\s+causas|causas\s+poss[ií]veis|hip[oó]teses\s+prov[aá]veis/i.test(text);
+    const hasCausas =
+      /poss[ií]veis\s+causas|causas\s+poss[ií]veis|hip[oó]teses\s+prov[aá]veis/i.test(text);
     if (!hasCausas) {
       const causas = await getPossibleCauses(session, body);
       if (causas.length) {
@@ -1155,7 +1753,6 @@ Além disso, ao chamar buildQuote, preencha o input com o máximo de contexto di
   return (text || '').trim() || null;
 }
 
-
 // Helper: extrai possíveis causas de blocos de conhecimento relevantes
 async function getPossibleCauses(session?: SessionRecord, lastMessage?: string): Promise<string[]> {
   try {
@@ -1164,18 +1761,30 @@ async function getPossibleCauses(session?: SessionRecord, lastMessage?: string):
     const extra = await fetchKnowledgeBlocks();
     const allBlocks = [...botBlocks, ...extra];
     const collected = (session as any)?.state?.dados_coletados || {};
-    const relevant = findRelevantBlocks(allBlocks, lastMessage || '', { equipamento: collected.equipamento, problema: collected.problema, marca: collected.marca });
+    const relevant = findRelevantBlocks(allBlocks, lastMessage || '', {
+      equipamento: collected.equipamento,
+      problema: collected.problema,
+      marca: collected.marca,
+    });
     let causasLista: string[] = [];
     for (const b of relevant) {
-      const arr = Array.isArray(b.data?.causas_possiveis) ? (b.data!.causas_possiveis as string[]) : [];
+      const arr = Array.isArray(b.data?.causas_possiveis)
+        ? (b.data!.causas_possiveis as string[])
+        : [];
       causasLista.push(...arr);
     }
     return Array.from(new Set(causasLista)).slice(0, 4);
-  } catch { return []; }
+  } catch {
+    return [];
+  }
 }
 
 // **NOVO: Roteador baseado 100% em IA**
-async function aiBasedRouting(from: string, body: string, session?: SessionRecord): Promise<string | null> {
+async function aiBasedRouting(
+  from: string,
+  body: string,
+  session?: SessionRecord
+): Promise<string | null> {
   try {
     console.log('[AI-ROUTER] 🎯 Analisando mensagem:', body.slice(0, 100));
 
@@ -1192,12 +1801,24 @@ async function aiBasedRouting(from: string, body: string, session?: SessionRecor
         } else if ((/fog[aã]o/.test(b) || /cook ?top/.test(b)) && /(g[aá]s|\bgas\b)/.test(b)) {
           targetEquip = 'fogão a gás';
         }
-        console.log('[AI-ROUTER] ⚠️ Troca de equipamento detectada via AI-router:', targetEquip, '(antes:', prevEquip, ')');
+        console.log(
+          '[AI-ROUTER] ⚠️ Troca de equipamento detectada via AI-router:',
+          targetEquip,
+          '(antes:',
+          prevEquip,
+          ')'
+        );
         const stAll = (session as any)?.state || {};
         const newDados: any = { ...stAll.dados_coletados, equipamento: targetEquip };
         delete newDados.marca;
         delete newDados.problema;
-        const newState: any = { ...stAll, dados_coletados: newDados, orcamento_entregue: false, last_quote: null, last_quote_ts: null };
+        const newState: any = {
+          ...stAll,
+          dados_coletados: newDados,
+          orcamento_entregue: false,
+          last_quote: null,
+          last_quote_ts: null,
+        };
         try {
           if ((session as any)?.id) await setSessionState((session as any).id, newState);
           (session as any).state = newState;
@@ -1247,12 +1868,12 @@ async function aiBasedRouting(from: string, body: string, session?: SessionRecor
     const sessionData = (session as any)?.state?.dados_coletados || {};
 
     // 3. Preparar contexto para a IA
-    const availableBlocks = allBlocks.map(b => ({
+    const availableBlocks = allBlocks.map((b) => ({
       key: b.key,
       description: b.description,
       equipamento: b.data?.equipamento,
       sintomas: b.data?.sintomas,
-      servicos_recomendados: b.data?.servicos_recomendados
+      servicos_recomendados: b.data?.servicos_recomendados,
     }));
 
     // 4. Usar IA para decidir roteamento completo
@@ -1271,14 +1892,18 @@ async function aiBasedRouting(from: string, body: string, session?: SessionRecor
         .replace(/forno da padaria/gi, 'forno comercial');
 
       if (originalResult !== normalizedResult) {
-        console.log('[AI-ROUTER] 📝 Nomenclatura normalizada:', originalResult.slice(0, 50), '→', normalizedResult.slice(0, 50));
+        console.log(
+          '[AI-ROUTER] 📝 Nomenclatura normalizada:',
+          originalResult.slice(0, 50),
+          '→',
+          normalizedResult.slice(0, 50)
+        );
       }
 
       return normalizedResult;
     }
 
     return result;
-
   } catch (e) {
     console.error('[AI-ROUTER] ❌ Erro completo:', e);
     console.error('[AI-ROUTER] ❌ Stack trace:', (e as Error)?.stack);
@@ -1288,7 +1913,11 @@ async function aiBasedRouting(from: string, body: string, session?: SessionRecor
 }
 
 // Helper: usa IA para gerar causas prováveis personalizadas
-async function generateAICauses(equipamento: string, problema: string, causasPossiveis: string[]): Promise<string[]> {
+async function generateAICauses(
+  equipamento: string,
+  problema: string,
+  causasPossiveis: string[]
+): Promise<string[]> {
   try {
     const prompt = `Com base no problema "${problema}" em um ${equipamento}, selecione e personalize as 3-4 causas mais prováveis desta lista:
 
@@ -1301,16 +1930,20 @@ Formato: uma causa por linha, sem numeração.`;
     const response = await chatComplete(
       { provider: 'openai', model: 'gpt-4o-mini', temperature: 0.7 },
       [
-        { role: 'system', content: 'Você é um técnico especialista em eletrodomésticos. Analise o problema e selecione as causas mais prováveis.' },
-        { role: 'user', content: prompt }
+        {
+          role: 'system',
+          content:
+            'Você é um técnico especialista em eletrodomésticos. Analise o problema e selecione as causas mais prováveis.',
+        },
+        { role: 'user', content: prompt },
       ]
     );
 
     if (response && typeof response === 'string') {
       const causas = response
         .split('\n')
-        .map(linha => linha.trim())
-        .filter(linha => linha && !linha.match(/^\d+\./) && linha.length > 10)
+        .map((linha) => linha.trim())
+        .filter((linha) => linha && !linha.match(/^\d+\./) && linha.length > 10)
         .slice(0, 4);
 
       console.log('[DEBUG] IA gerou causas:', causas);
@@ -1385,7 +2018,7 @@ ${guidance}
   } catch {}
 
 BLOCOS_DISPONIVEIS:
-${availableBlocks.map((b, i) => `${i + 1}. ${b.key} | eq=${b.equipamento || 'N/A'} | sintomas=${(b.sintomas||[]).slice(0,6).join(', ')}`).join('\n')}
+${availableBlocks.map((b, i) => `${i + 1}. ${b.key} | eq=${b.equipamento || 'N/A'} | sintomas=${(b.sintomas || []).slice(0, 6).join(', ')}`).join('\n')}
 
 Retorne:
 {
@@ -1402,8 +2035,12 @@ Retorne:
   const response = await chatComplete(
     { provider: 'openai', model: 'gpt-4o-mini', temperature: 0.2 },
     [
-      { role: 'system', content: 'Você é um especialista em roteamento. Retorne exclusivamente JSON válido que obedece ao schema. Não inclua explicações.' },
-      { role: 'user', content: prompt }
+      {
+        role: 'system',
+        content:
+          'Você é um especialista em roteamento. Retorne exclusivamente JSON válido que obedece ao schema. Não inclua explicações.',
+      },
+      { role: 'user', content: prompt },
     ]
   );
 
@@ -1416,7 +2053,7 @@ Retorne:
     raw = raw.replace(/```/g, '');
     const first = raw.indexOf('{');
     const last = raw.lastIndexOf('}');
-    const candidate = (first >= 0 && last > first) ? raw.slice(first, last + 1) : raw.trim();
+    const candidate = first >= 0 && last > first ? raw.slice(first, last + 1) : raw.trim();
 
     const decision = JSON.parse(candidate);
 
@@ -1457,9 +2094,12 @@ async function executeAIDecision(
       // Preservar especificadores quando já coletados (ex.: "fogão a gás")
       try {
         const curEq = String(currentData.equipamento || '').toLowerCase();
-        const newEq = String(decision.dados_extrair.equipamento || merged.equipamento || '').toLowerCase();
+        const newEq = String(
+          decision.dados_extrair.equipamento || merged.equipamento || ''
+        ).toLowerCase();
         const curIsGas = /g[aá]s/.test(curEq);
-        const newIsGenericFogao = /\bfog(ão|ao)\b/.test(newEq) && !/g[aá]s|indu(c|ç)ão|el[eé]trico/.test(newEq);
+        const newIsGenericFogao =
+          /\bfog(ão|ao)\b/.test(newEq) && !/g[aá]s|indu(c|ç)ão|el[eé]trico/.test(newEq);
         if (curIsGas && newIsGenericFogao) {
           merged.equipamento = currentData.equipamento; // mantém "fogão a gás"
           merged.power_type = merged.power_type || 'gas';
@@ -1474,19 +2114,46 @@ async function executeAIDecision(
 
     // 2. Ajustes específicos por intenção (melhor UX)
     const prIntent = detectPriorityIntent(body);
-    if (prIntent === 'reagendamento' || (decision.intent === 'reagendamento' && decision.acao_principal === 'coletar_dados')) {
-      const reply = 'Perfeito! Para reagendar, me informe o número da sua OS (se tiver). Se não tiver, me passe nome, telefone e endereço. Qual a melhor data e horário para você?';
-      await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'reagendamento', acao_principal: 'coletar_dados' }, reply });
+    if (
+      prIntent === 'reagendamento' ||
+      (decision.intent === 'reagendamento' && decision.acao_principal === 'coletar_dados')
+    ) {
+      const reply =
+        'Perfeito! Para reagendar, me informe o número da sua OS (se tiver). Se não tiver, me passe nome, telefone e endereço. Qual a melhor data e horário para você?';
+      await logAIRoute('ai_route_effective', {
+        from,
+        body,
+        original: decision,
+        effective: { intent: 'reagendamento', acao_principal: 'coletar_dados' },
+        reply,
+      });
       return sanitizeAIText(reply);
     }
     if (prIntent === 'cancelamento' || decision.intent === 'cancelamento') {
-      const reply = 'Tudo certo! Para concluir o cancelamento, me informe o número da sua OS. Se não tiver, me passe nome, telefone e endereço que localizo seu atendimento para cancelar.';
-      await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'cancelamento', acao_principal: 'coletar_dados' }, reply });
+      const reply =
+        'Tudo certo! Para concluir o cancelamento, me informe o número da sua OS. Se não tiver, me passe nome, telefone e endereço que localizo seu atendimento para cancelar.';
+      await logAIRoute('ai_route_effective', {
+        from,
+        body,
+        original: decision,
+        effective: { intent: 'cancelamento', acao_principal: 'coletar_dados' },
+        reply,
+      });
       return sanitizeAIText(reply);
     }
-    if (prIntent === 'instalacao' || (decision.intent === 'instalacao' && decision.acao_principal === 'coletar_dados')) {
-      const reply = 'Legal! Para a instalação, preciso de: equipamento, tipo (embutido ou bancada), local exato de instalação, voltagem (127V/220V), distância do ponto de gás/energia e se já há fixação/suportes. Pode me passar esses dados?';
-      await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'instalacao', acao_principal: 'coletar_dados' }, reply });
+    if (
+      prIntent === 'instalacao' ||
+      (decision.intent === 'instalacao' && decision.acao_principal === 'coletar_dados')
+    ) {
+      const reply =
+        'Legal! Para a instalação, preciso de: equipamento, tipo (embutido ou bancada), local exato de instalação, voltagem (127V/220V), distância do ponto de gás/energia e se já há fixação/suportes. Pode me passar esses dados?';
+      await logAIRoute('ai_route_effective', {
+        from,
+        body,
+        original: decision,
+        effective: { intent: 'instalacao', acao_principal: 'coletar_dados' },
+        reply,
+      });
       return sanitizeAIText(reply);
     }
 
@@ -1499,10 +2166,11 @@ async function executeAIDecision(
         try {
           const sessionData = (session as any)?.state?.dados_coletados || {};
           const hasEquipmentContext = !!sessionData.equipamento;
-          const agendamentoKeywords = /\b(agendar|marcar|aceito|aceitar|quero|vamos|sim|ok|beleza|pode|vou|gostaria|confirmo|fechado|fechou)\b/i;
+          const agendamentoKeywords =
+            /\b(agendar|marcar|aceito|aceitar|quero|vamos|sim|ok|beleza|pode|vou|gostaria|confirmo|fechado|fechou)\b/i;
           const isAgendamentoIntent = agendamentoKeywords.test(body || '');
           const accepted = hasExplicitAcceptance(body || '');
-          const hasQuoteDelivered = !!((session as any)?.state?.orcamento_entregue);
+          const hasQuoteDelivered = !!(session as any)?.state?.orcamento_entregue;
           if (hasEquipmentContext && hasQuoteDelivered && (accepted || isAgendamentoIntent)) {
             out = await executeAIAgendamento(decision, session, body, from);
             break;
@@ -1523,13 +2191,23 @@ Mensagem do usuário: "${body}"
 
 Responda de forma natural e brasileira como uma pessoa real faria. Cumprimente de volta e depois pergunte como pode ajudar com equipamentos domésticos.`;
 
-            const response = await chatComplete({ provider: 'openai', model: process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini' }, [
-              { role: 'system', content: saudacaoPrompt },
-              { role: 'user', content: body || '' }
-            ]);
+            const response = await chatComplete(
+              { provider: 'openai', model: process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini' },
+              [
+                { role: 'system', content: saudacaoPrompt },
+                { role: 'user', content: body || '' },
+              ]
+            );
 
-            out = response || decision.resposta_sugerida || 'Oi! Tudo bem? Como posso te ajudar hoje?';
-            await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'saudacao_inicial', acao_principal: 'resposta_humanizada' }, reply: out });
+            out =
+              response || decision.resposta_sugerida || 'Oi! Tudo bem? Como posso te ajudar hoje?';
+            await logAIRoute('ai_route_effective', {
+              from,
+              body,
+              original: decision,
+              effective: { intent: 'saudacao_inicial', acao_principal: 'resposta_humanizada' },
+              reply: out,
+            });
           } catch (e) {
             console.log('[DEBUG] Erro no GPT humanizado, usando fallback:', e);
             out = decision.resposta_sugerida || 'Oi! Tudo bem? Como posso te ajudar hoje?';
@@ -1538,26 +2216,52 @@ Responda de forma natural e brasileira como uma pessoa real faria. Cumprimente d
           // Override por prioridade de intenção (outras situações)
           const pr = detectPriorityIntent(body);
           if (pr === 'reagendamento') {
-            out = 'Perfeito! Para reagendar, me informe o número da sua OS (se tiver). Se não tiver, me passe nome, telefone e endereço. Qual a melhor data e horário para você?';
-            await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'reagendamento', acao_principal: 'coletar_dados' }, reply: out });
+            out =
+              'Perfeito! Para reagendar, me informe o número da sua OS (se tiver). Se não tiver, me passe nome, telefone e endereço. Qual a melhor data e horário para você?';
+            await logAIRoute('ai_route_effective', {
+              from,
+              body,
+              original: decision,
+              effective: { intent: 'reagendamento', acao_principal: 'coletar_dados' },
+              reply: out,
+            });
           } else if (pr === 'cancelamento') {
-            out = 'Tudo certo! Para concluir o cancelamento, me informe o número da sua OS. Se não tiver, me passe nome, telefone e endereço que localizo seu atendimento para cancelar.';
-            await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'cancelamento', acao_principal: 'coletar_dados' }, reply: out });
+            out =
+              'Tudo certo! Para concluir o cancelamento, me informe o número da sua OS. Se não tiver, me passe nome, telefone e endereço que localizo seu atendimento para cancelar.';
+            await logAIRoute('ai_route_effective', {
+              from,
+              body,
+              original: decision,
+              effective: { intent: 'cancelamento', acao_principal: 'coletar_dados' },
+              reply: out,
+            });
           } else if (pr === 'instalacao') {
-            out = 'Legal! Para a instalação, preciso de: equipamento, tipo (embutido ou bancada), local exato de instalação, voltagem (127V/220V), distância do ponto de gás/energia e se já há fixação/suportes. Pode me passar esses dados?';
-            await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'instalacao', acao_principal: 'coletar_dados' }, reply: out });
+            out =
+              'Legal! Para a instalação, preciso de: equipamento, tipo (embutido ou bancada), local exato de instalação, voltagem (127V/220V), distância do ponto de gás/energia e se já há fixação/suportes. Pode me passar esses dados?';
+            await logAIRoute('ai_route_effective', {
+              from,
+              body,
+              original: decision,
+              effective: { intent: 'instalacao', acao_principal: 'coletar_dados' },
+              reply: out,
+            });
           } else {
             // SISTEMA DE CONTEXTO INTELIGENTE
             const sessionData = (session as any)?.state?.dados_coletados || {};
             const hasEquipmentContext = !!sessionData.equipamento;
 
             // Detectar intenção de agendamento (palavras-chave amplas)
-            const agendamentoKeywords = /\b(agendar|marcar|aceito|aceitar|quero|vamos|sim|ok|beleza|pode|vou|gostaria|confirmo|fechado|fechou)\b/i;
+            const agendamentoKeywords =
+              /\b(agendar|marcar|aceito|aceitar|quero|vamos|sim|ok|beleza|pode|vou|gostaria|confirmo|fechado|fechou)\b/i;
             const isAgendamentoIntent = agendamentoKeywords.test(body || '');
 
-            const hasQuoteDelivered2 = !!((session as any)?.state?.orcamento_entregue);
+            const hasQuoteDelivered2 = !!(session as any)?.state?.orcamento_entregue;
             const acceptedPlain2 = hasExplicitAcceptance(body || '');
-            if (hasEquipmentContext && (hasQuoteDelivered2 || acceptedPlain2) && isAgendamentoIntent) {
+            if (
+              hasEquipmentContext &&
+              (hasQuoteDelivered2 || acceptedPlain2) &&
+              isAgendamentoIntent
+            ) {
               // Se temos contexto de equipamento E orçamento já foi entregue E usuário demonstra intenção de agendamento
               out = await executeAIAgendamento(decision, session, body, from);
             } else if (hasExplicitAcceptance(body || '')) {
@@ -1565,7 +2269,8 @@ Responda de forma natural e brasileira como uma pessoa real faria. Cumprimente d
               if (hasEquipmentContext && hasQuoteDelivered2) {
                 out = await executeAIAgendamento(decision, session, body, from);
               } else if (hasEquipmentContext && !hasQuoteDelivered2) {
-                out = 'Antes de agendarmos, vou te passar o valor e as possíveis causas para alinharmos. Pode me confirmar marca e um breve descritivo do defeito?';
+                out =
+                  'Antes de agendarmos, vou te passar o valor e as possíveis causas para alinharmos. Pode me confirmar marca e um breve descritivo do defeito?';
               } else {
                 out = 'Vou transferir você para um de nossos especialistas. Um momento, por favor.';
               }
@@ -1582,16 +2287,23 @@ Responda de forma natural e brasileira como uma pessoa real faria. Cumprimente d
                   try {
                     const { getTemplates, renderTemplate } = await import('./botConfig.js');
                     const tpls = await getTemplates();
-                    const askBrand = tpls.find((t:any)=>t.key==='ask-brand');
-                    if (askBrand?.content) out = renderTemplate(askBrand.content, { equipamento: String(eq) });
+                    const askBrand = tpls.find((t: any) => t.key === 'ask-brand');
+                    if (askBrand?.content)
+                      out = renderTemplate(askBrand.content, { equipamento: String(eq) });
                     else out = `Certo! Qual é a marca do seu ${eq}?`;
-                  } catch { out = `Certo! Qual é a marca do seu ${eq}?`; }
+                  } catch {
+                    out = `Certo! Qual é a marca do seu ${eq}?`;
+                  }
                 } else if (eq && brand && !prob) {
                   try {
                     const { getTemplates, renderTemplate } = await import('./botConfig.js');
                     const tpls = await getTemplates();
-                    const askProblem = tpls.find((t:any)=>t.key==='ask-problem');
-                    if (askProblem?.content) out = renderTemplate(askProblem.content, { equipamento: String(eq), marca: brand?String(brand):'' });
+                    const askProblem = tpls.find((t: any) => t.key === 'ask-problem');
+                    if (askProblem?.content)
+                      out = renderTemplate(askProblem.content, {
+                        equipamento: String(eq),
+                        marca: brand ? String(brand) : '',
+                      });
                     else {
                       const brandTxt = brand ? ` da marca ${brand}` : '';
                       out = `Olá! Poderia me informar qual é o problema que você está enfrentando com seu ${eq}${brandTxt}?`;
@@ -1605,10 +2317,15 @@ Responda de forma natural e brasileira como uma pessoa real faria. Cumprimente d
                   try {
                     const { getTemplates, renderTemplate } = await import('./botConfig.js');
                     const tpls = await getTemplates();
-                    const offTopic = tpls.find((t:any)=>t.key==='off_topic');
-                    out = offTopic?.content ? renderTemplate(offTopic.content, {}) : (decision.resposta_sugerida || 'Posso te ajudar com orçamento, agendamento ou status. Qual prefere?');
+                    const offTopic = tpls.find((t: any) => t.key === 'off_topic');
+                    out = offTopic?.content
+                      ? renderTemplate(offTopic.content, {})
+                      : decision.resposta_sugerida ||
+                        'Posso te ajudar com orçamento, agendamento ou status. Qual prefere?';
                   } catch {
-                    out = decision.resposta_sugerida || 'Posso te ajudar com orçamento, agendamento ou status. Qual prefere?';
+                    out =
+                      decision.resposta_sugerida ||
+                      'Posso te ajudar com orçamento, agendamento ou status. Qual prefere?';
                   }
                 }
               } catch {
@@ -1623,7 +2340,7 @@ Responda de forma natural e brasileira como uma pessoa real faria. Cumprimente d
         break;
       case 'agendar_servico':
         // Evitar chamadas externas no ambiente de teste quando orçamento não foi entregue ainda
-        if (process.env.NODE_ENV === 'test' && !((session as any)?.state?.orcamento_entregue)) {
+        if (process.env.NODE_ENV === 'test' && !(session as any)?.state?.orcamento_entregue) {
           return 'Vamos primeiro finalizar o orçamento para seguir com o agendamento. Posso te passar os valores?';
         }
         out = await executeAIAgendamento(decision, session, body, from);
@@ -1648,17 +2365,43 @@ Exemplos:
 - "Você gosta de futebol?" → "Ah, eu curto sim! E você, torce pra qual time? Mas me diz, precisa de ajuda com algum equipamento em casa?"
 - "Me conta uma piada" → "Haha, não sou muito bom com piadas não! 😅 Mas sou ótimo com equipamentos! Posso te ajudar com alguma coisa?"`;
 
-            const response = await chatComplete({ provider: 'openai', model: process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini' }, [
-              { role: 'system', content: perguntaPrompt },
-              { role: 'user', content: body || '' }
-            ]);
+            const response = await chatComplete(
+              { provider: 'openai', model: process.env.LLM_OPENAI_MODEL || 'gpt-4o-mini' },
+              [
+                { role: 'system', content: perguntaPrompt },
+                { role: 'user', content: body || '' },
+              ]
+            );
 
-            out = response || decision.resposta_sugerida || 'Interessante! 😊 Mas me diz, posso te ajudar com algum equipamento doméstico?';
-            await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'outros', acao_principal: 'resposta_humanizada_redirecionamento' }, reply: out });
+            out =
+              response ||
+              decision.resposta_sugerida ||
+              'Interessante! 😊 Mas me diz, posso te ajudar com algum equipamento doméstico?';
+            await logAIRoute('ai_route_effective', {
+              from,
+              body,
+              original: decision,
+              effective: {
+                intent: 'outros',
+                acao_principal: 'resposta_humanizada_redirecionamento',
+              },
+              reply: out,
+            });
           } catch (e) {
-            console.log('[DEBUG] Erro no GPT humanizado para pergunta aleatória, usando fallback:', e);
-            out = decision.resposta_sugerida || 'Interessante! 😊 Mas me diz, posso te ajudar com algum equipamento doméstico?';
-            await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'outros', acao_principal: 'fallback' }, reply: out });
+            console.log(
+              '[DEBUG] Erro no GPT humanizado para pergunta aleatória, usando fallback:',
+              e
+            );
+            out =
+              decision.resposta_sugerida ||
+              'Interessante! 😊 Mas me diz, posso te ajudar com algum equipamento doméstico?';
+            await logAIRoute('ai_route_effective', {
+              from,
+              body,
+              original: decision,
+              effective: { intent: 'outros', acao_principal: 'fallback' },
+              reply: out,
+            });
           }
         } else {
           // SISTEMA DE CONTEXTO INTELIGENTE (outros casos)
@@ -1666,12 +2409,17 @@ Exemplos:
           const hasEquipmentContext = !!sessionData.equipamento;
 
           // Detectar intenção de agendamento (palavras-chave amplas)
-          const agendamentoKeywords = /\b(agendar|marcar|aceito|aceitar|quero|vamos|sim|ok|beleza|pode|vou|gostaria|confirmo|fechado|fechou)\b/i;
+          const agendamentoKeywords =
+            /\b(agendar|marcar|aceito|aceitar|quero|vamos|sim|ok|beleza|pode|vou|gostaria|confirmo|fechado|fechou)\b/i;
           const isAgendamentoIntent = agendamentoKeywords.test(body || '');
 
-          const hasQuoteDelivered3 = !!((session as any)?.state?.orcamento_entregue);
+          const hasQuoteDelivered3 = !!(session as any)?.state?.orcamento_entregue;
           const acceptedPlain3 = hasExplicitAcceptance(body || '');
-          if (hasEquipmentContext && (hasQuoteDelivered3 || acceptedPlain3) && isAgendamentoIntent) {
+          if (
+            hasEquipmentContext &&
+            (hasQuoteDelivered3 || acceptedPlain3) &&
+            isAgendamentoIntent
+          ) {
             // Se temos contexto de equipamento E orçamento já foi entregue E usuário demonstra intenção de agendamento
             out = await executeAIAgendamento(decision, session, body, from);
           } else if (hasExplicitAcceptance(body || '')) {
@@ -1679,7 +2427,8 @@ Exemplos:
             if (hasEquipmentContext && hasQuoteDelivered3) {
               out = await executeAIAgendamento(decision, session, body, from);
             } else if (hasEquipmentContext && !hasQuoteDelivered3) {
-              out = 'Antes de agendarmos, vou te passar o valor e as possíveis causas para alinharmos. Pode me confirmar marca e um breve descritivo do defeito?';
+              out =
+                'Antes de agendarmos, vou te passar o valor e as possíveis causas para alinharmos. Pode me confirmar marca e um breve descritivo do defeito?';
             } else {
               out = 'Vou transferir você para um de nossos especialistas. Um momento, por favor.';
             }
@@ -1689,54 +2438,69 @@ Exemplos:
         }
     }
 
-function detectPriorityIntent(text: string): string | null {
-  const normalize = (s:string)=> s.normalize('NFD').replace(/\p{Diacritic}/gu,'').toLowerCase();
-  const b = normalize(text||'');
-  if (/(\breagendar\b|\breagendamento\b|trocar horario|nova data|remarcar)/.test(b)) return 'reagendamento';
-  if (/(\bcancelar\b|\bcancelamento\b|desmarcar)/.test(b)) return 'cancelamento';
-  if (/(\bstatus\b|acompanhar|andamento|numero da os|n[ºo]\s*da\s*os|numero da ordem)/.test(b)) return 'status_ordem';
-  if (/(instalar|instalacao|instala\u00e7\u00e3o)/.test(b)) return 'instalacao';
-  return null;
-}
-
+    function detectPriorityIntent(text: string): string | null {
+      const normalize = (s: string) =>
+        s
+          .normalize('NFD')
+          .replace(/\p{Diacritic}/gu, '')
+          .toLowerCase();
+      const b = normalize(text || '');
+      if (/(\breagendar\b|\breagendamento\b|trocar horario|nova data|remarcar)/.test(b))
+        return 'reagendamento';
+      if (/(\bcancelar\b|\bcancelamento\b|desmarcar)/.test(b)) return 'cancelamento';
+      if (/(\bstatus\b|acompanhar|andamento|numero da os|n[ºo]\s*da\s*os|numero da ordem)/.test(b))
+        return 'status_ordem';
+      if (/(instalar|instalacao|instala\u00e7\u00e3o)/.test(b)) return 'instalacao';
+      return null;
+    }
 
     // Sanitizar pedidos de dados pessoais antes do aceite explícito
     if (out) {
       out = sanitizeSensitiveRequests(out, hasExplicitAcceptance(body));
     }
     return sanitizeAIText(out || '');
-
   } catch (e) {
     console.error('[AI-ROUTER] ❌ Erro ao executar decisão:', e);
-    return sanitizeAIText(decision.resposta_sugerida || 'Desculpe, houve um problema. Pode repetir sua solicitação?');
+    return sanitizeAIText(
+      decision.resposta_sugerida || 'Desculpe, houve um problema. Pode repetir sua solicitação?'
+    );
   }
 }
 
 // Remove prefaces/artefatos da IA
 function sanitizeAIText(text: string): string {
-  let t = (text||'')
-    .replace(/^\s*[-*_]{3,}\s*$/gm,'') // --- linhas
-    .replace(/aqui\s+est[áa]\s+uma\s+resposta[^:]*:?\s*/gi,'')
-    .replace(/aqui\s+est[áa]\s*:?\s*/gi,'')
-    .replace(/aqui\s+vai\s*:?\s*/gi,'')
-    .replace(/\s{3,}/g,' ')
+  let t = (text || '')
+    .replace(/^\s*[-*_]{3,}\s*$/gm, '') // --- linhas
+    .replace(/aqui\s+est[áa]\s+uma\s+resposta[^:]*:?\s*/gi, '')
+    .replace(/aqui\s+est[áa]\s*:?\s*/gi, '')
+    .replace(/aqui\s+vai\s*:?\s*/gi, '')
+    .replace(/\s{3,}/g, ' ')
     .trim();
   try {
     // Se a sessão não tem marca coletada, evite que a resposta "natural" invente marcas
-    const state:any = (global as any)?.current_session_state_for_sanitizer || null;
+    const state: any = (global as any)?.current_session_state_for_sanitizer || null;
     const hasBrand = !!state?.dados_coletados?.marca;
     if (!hasBrand) {
-      t = t.replace(/\b(Brastemp|Consul|Electrolux|Fischer|Suggar|Tramontina|Mueller|Samsung|LG|Philco|Midea|Bosch|GE)\b/gi, '');
-      t = t.replace(/\s{2,}/g,' ').replace(/\s([,.!?])/g,'$1').trim();
+      t = t.replace(
+        /\b(Brastemp|Consul|Electrolux|Fischer|Suggar|Tramontina|Mueller|Samsung|LG|Philco|Midea|Bosch|GE)\b/gi,
+        ''
+      );
+      t = t
+        .replace(/\s{2,}/g, ' ')
+        .replace(/\s([,.!?])/g, '$1')
+        .trim();
     }
   } catch {}
   return t;
 }
 
-
 // **FUNÇÕES DE EXECUÇÃO ESPECÍFICAS**
 
-async function executeAIOrçamento(decision: any, session?: SessionRecord, body?: string): Promise<string> {
+async function executeAIOrçamento(
+  decision: any,
+  session?: SessionRecord,
+  body?: string
+): Promise<string> {
   try {
     let dados: any = decision.dados_extrair || {};
     const { buildQuote } = await import('./toolsRuntime.js');
@@ -1750,8 +2514,14 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
 
     // Se há equipamento anterior com especificador "a gás" e o novo veio genérico
     try {
-      const prevEq = String((session as any)?.state?.dados_coletados?.equipamento || '').toLowerCase();
-      if (/g[aá]s/.test(prevEq) && /\bfog(ão|ao)\b/.test(String(equipment || '').toLowerCase()) && !/g[aá]s|indu(c|ç)ão|el[eé]trico/.test(String(equipment || '').toLowerCase())) {
+      const prevEq = String(
+        (session as any)?.state?.dados_coletados?.equipamento || ''
+      ).toLowerCase();
+      if (
+        /g[aá]s/.test(prevEq) &&
+        /\bfog(ão|ao)\b/.test(String(equipment || '').toLowerCase()) &&
+        !/g[aá]s|indu(c|ç)ão|el[eé]trico/.test(String(equipment || '').toLowerCase())
+      ) {
         equipment = (session as any)?.state?.dados_coletados?.equipamento;
       }
     } catch {}
@@ -1763,7 +2533,11 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
 
     // Regra explícita: fogão/cooktop a gás é atendimento em domicílio
     const equipLower = (equipment || '').toLowerCase();
-    const saysGas = /(g[aá]s)/i.test(equipLower) || /(g[aá]s)/i.test(String((session as any)?.state?.dados_coletados?.power_type || '')) || /(g[aá]s)/i.test(String((dados.power_type || '')).toLowerCase()) || /\bgas\b/.test(String((session as any)?.state?.last_raw_message || '').toLowerCase());
+    const saysGas =
+      /(g[aá]s)/i.test(equipLower) ||
+      /(g[aá]s)/i.test(String((session as any)?.state?.dados_coletados?.power_type || '')) ||
+      /(g[aá]s)/i.test(String(dados.power_type || '').toLowerCase()) ||
+      /\bgas\b/.test(String((session as any)?.state?.last_raw_message || '').toLowerCase());
 
     // 🔥 COLETA DETALHADA PARA FOGÕES A GÁS
     if ((/\bfog(ão|ao)\b/i.test(equipLower) || /\bcook ?top\b/i.test(equipLower)) && saysGas) {
@@ -1775,14 +2549,22 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
       }
 
       // Limpar dados incorretos extraídos pela IA
-      if (dados.mount && !['piso', 'cooktop', 'embutido', 'bancada'].includes(dados.mount.toLowerCase())) {
+      if (
+        dados.mount &&
+        !['piso', 'cooktop', 'embutido', 'bancada'].includes(dados.mount.toLowerCase())
+      ) {
         console.log('[FOGÃO DEBUG] Mount inválido detectado:', dados.mount, '- removendo');
         dados.mount = null;
       }
 
       // RESET COMPLETO: Se é uma nova conversa sobre fogão, limpar TUDO
-      const isFogaoMessage = body && (body.toLowerCase().includes('fogão') || body.toLowerCase().includes('fogao'));
-      const hasNegation = body && (body.toLowerCase().includes('não') || body.toLowerCase().includes('nao') || body.toLowerCase().includes('nã'));
+      const isFogaoMessage =
+        body && (body.toLowerCase().includes('fogão') || body.toLowerCase().includes('fogao'));
+      const hasNegation =
+        body &&
+        (body.toLowerCase().includes('não') ||
+          body.toLowerCase().includes('nao') ||
+          body.toLowerCase().includes('nã'));
 
       if (isFogaoMessage && hasNegation) {
         console.log('[FOGÃO DEBUG] DETECTADO: Nova conversa sobre fogão com negação');
@@ -1799,9 +2581,16 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
           mount: null,
           problema: 'não acende',
           equipamento: 'fogão',
-          marca: dados.marca || null // Manter marca se existir
+          marca: dados.marca || null, // Manter marca se existir
         };
-        try { if ((session as any)?.id) await setSessionState((session as any).id, { ...(session as any).state, dados_coletados: dados, pendingEquipmentType: 'fogao' }); } catch {}
+        try {
+          if ((session as any)?.id)
+            await setSessionState((session as any).id, {
+              ...(session as any).state,
+              dados_coletados: dados,
+              pendingEquipmentType: 'fogao',
+            });
+        } catch {}
         console.log('[FOGÃO DEBUG] DADOS FORÇADAMENTE LIMPOS + pendingEquipmentType=fogao:', dados);
       }
 
@@ -1813,7 +2602,7 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
         num_burners: dados.num_burners,
         needsMoreInfo,
         fogao_info_collected: (session as any)?.state?.fogao_info_collected,
-        body: body
+        body: body,
       });
 
       // Detectar informações da mensagem atual SEMPRE
@@ -1837,30 +2626,39 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
       }
 
       // Se ainda faltam informações, perguntar (mas só uma vez por conversa de fogão)
-      if (needsMoreInfo && !(session as any)?.state?.fogao_info_collected && process.env.NODE_ENV !== 'test' && !process.env.LLM_FAKE_JSON) {
+      if (
+        needsMoreInfo &&
+        !(session as any)?.state?.fogao_info_collected &&
+        process.env.NODE_ENV !== 'test' &&
+        !process.env.LLM_FAKE_JSON
+      ) {
         // Garantir que session.state existe
         if (!(session as any).state) (session as any).state = {} as any;
 
         // Marcar que já tentamos coletar info para evitar loop
         (session as any).state.fogao_info_collected = true;
 
-        let pergunta = "Para dar um orçamento mais preciso, preciso saber:\n\n";
+        let pergunta = 'Para dar um orçamento mais preciso, preciso saber:\n\n';
 
         if (!dados.mount) {
-          pergunta += "🔹 É fogão de piso ou cooktop?\n";
+          pergunta += '🔹 É fogão de piso ou cooktop?\n';
         }
 
         if (!dados.num_burners) {
-          pergunta += "🔹 Quantas bocas tem? (4, 5 ou 6 bocas)\n";
+          pergunta += '🔹 Quantas bocas tem? (4, 5 ou 6 bocas)\n';
         }
 
-        pergunta += "\nCom essas informações posso dar o valor exato do atendimento! 😊";
+        pergunta += '\nCom essas informações posso dar o valor exato do atendimento! 😊';
 
         // Prefixo com equipamento quando reconhecido (ex.: fogão a gás)
         try {
           const eqName = (equipment || '').toLowerCase();
           const hasGas = /g[aá]s/.test(eqName) || /\bgas\b/.test(eqName);
-          const prefix = hasGas ? 'Para o seu fogão a gás: ' : ((equipment||'').trim() ? `Para o seu ${equipment}: ` : '');
+          const prefix = hasGas
+            ? 'Para o seu fogão a gás: '
+            : (equipment || '').trim()
+              ? `Para o seu ${equipment}: `
+              : '';
           pergunta = prefix + pergunta;
         } catch {}
 
@@ -1868,7 +2666,7 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
         if (session) {
           await setSessionState(session.id, {
             dados_coletados: { ...session.state?.dados_coletados, ...dados },
-            fogao_info_collected: true
+            fogao_info_collected: true,
           });
         }
 
@@ -1889,15 +2687,29 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
         equipment = 'fogão industrial';
       } else if (/(forno.*industrial|industrial.*forno)/i.test(equipamento + ' ' + (body || ''))) {
         equipment = 'forno industrial';
-      } else if (/(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno|forno.*médio.*porte|médio.*porte.*forno)/i.test(equipamento + ' ' + (body || ''))) {
+      } else if (
+        /(forno.*padaria|padaria.*forno|forno.*comercial|comercial.*forno|forno.*médio.*porte|médio.*porte.*forno)/i.test(
+          equipamento + ' ' + (body || '')
+        )
+      ) {
         equipment = 'forno comercial';
-      } else if (/(geladeira.*comercial|comercial.*geladeira|refrigerador.*comercial)/i.test(equipamento + ' ' + (body || ''))) {
+      } else if (
+        /(geladeira.*comercial|comercial.*geladeira|refrigerador.*comercial)/i.test(
+          equipamento + ' ' + (body || '')
+        )
+      ) {
         equipment = 'geladeira comercial';
       }
     }
 
     // Passar mount/power_type quando disponível para permitir classificação correta no buildQuote
-    const power_type = /g[aá]s/i.test(equipment) ? 'gas' : (/induc/i.test(equipment) ? 'inducao' : (/el[eé]tr/i.test(equipment) ? 'eletrico' : (dados.power_type || null)));
+    const power_type = /g[aá]s/i.test(equipment)
+      ? 'gas'
+      : /induc/i.test(equipment)
+        ? 'inducao'
+        : /el[eé]tr/i.test(equipment)
+          ? 'eletrico'
+          : dados.power_type || null;
 
     // Detectar informações adicionais da mensagem para fogões
     let num_burners = dados.num_burners;
@@ -1934,7 +2746,7 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
       mount: mount || null,
       power_type: power_type || null,
       num_burners: num_burners || null,
-      segment: segment || null
+      segment: segment || null,
     } as any);
 
     if (quote) {
@@ -1943,11 +2755,29 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
         const eq = (equipment || '').toLowerCase();
         const prob = (problema || '').toLowerCase();
         if (eq.includes('adega')) {
-          const causasAdega = (/não gela|nao gela|parou de esfriar|não esfria|nao esfria/i.test(prob)
-            ? ['Ventilador do evaporador defeituoso','Condensador sujo','Gás refrigerante insuficiente','Compressor com falha','Sensor/termostato (NTC)','Placa eletrônica','Vedação da porta danificada']
+          const causasAdega = /não gela|nao gela|parou de esfriar|não esfria|nao esfria/i.test(prob)
+            ? [
+                'Ventilador do evaporador defeituoso',
+                'Condensador sujo',
+                'Gás refrigerante insuficiente',
+                'Compressor com falha',
+                'Sensor/termostato (NTC)',
+                'Placa eletrônica',
+                'Vedação da porta danificada',
+              ]
             : /não liga|nao liga/i.test(prob)
-            ? ['Alimentação elétrica/fusível','Placa eletrônica','Termostato de segurança','Chave/interruptor']
-            : ['Sistema de refrigeração','Sensor de temperatura (NTC)','Ventilador interno','Placa eletrônica']);
+              ? [
+                  'Alimentação elétrica/fusível',
+                  'Placa eletrônica',
+                  'Termostato de segurança',
+                  'Chave/interruptor',
+                ]
+              : [
+                  'Sistema de refrigeração',
+                  'Sensor de temperatura (NTC)',
+                  'Ventilador interno',
+                  'Placa eletrônica',
+                ];
           if (Array.isArray(causasAdega) && causasAdega.length > 0) {
             (quote as any).causas_possiveis = causasAdega;
           }
@@ -1959,15 +2789,17 @@ async function executeAIOrçamento(decision: any, session?: SessionRecord, body?
     }
 
     // Aplicar pós-processamento de nomenclatura
-    const fallbackResponse = decision.resposta_sugerida || 'Vou preparar um orçamento para você. Um momento...';
+    const fallbackResponse =
+      decision.resposta_sugerida || 'Vou preparar um orçamento para você. Um momento...';
     return fallbackResponse
       .replace(/forno de padaria/gi, 'forno comercial')
       .replace(/forno da padaria/gi, 'forno comercial');
-
   } catch (e) {
     console.error('[AI-ROUTER] ❌ Erro no orçamento:', e);
     // Aplicar pós-processamento de nomenclatura mesmo em caso de erro
-    const errorResponse = decision.resposta_sugerida || 'Houve um problema ao gerar o orçamento. Pode tentar novamente?';
+    const errorResponse =
+      decision.resposta_sugerida ||
+      'Houve um problema ao gerar o orçamento. Pode tentar novamente?';
     return errorResponse
       .replace(/forno de padaria/gi, 'forno comercial')
       .replace(/forno da padaria/gi, 'forno comercial');
@@ -1981,9 +2813,7 @@ async function executeAIInformacao(decision: any, allBlocks?: any[]): Promise<st
       .map((index: number) => allBlocks[index - 1])
       .filter(Boolean);
 
-    const info = relevantBlocks
-      .map((b: any) => b.data?.raw_text || b.description)
-      .join('\n\n');
+    const info = relevantBlocks.map((b: any) => b.data?.raw_text || b.description).join('\n\n');
 
     if (info) {
       // Usar IA para formatar a resposta baseada nas informações encontradas
@@ -1994,17 +2824,36 @@ async function executeAIInformacao(decision: any, allBlocks?: any[]): Promise<st
   return decision.resposta_sugerida || 'Posso ajudar com mais alguma coisa?';
 }
 
-async function executeAIAgendamento(decision: any, session?: SessionRecord, body?: string, from?: string): Promise<string> {
+async function executeAIAgendamento(
+  decision: any,
+  session?: SessionRecord,
+  body?: string,
+  from?: string
+): Promise<string> {
   // 0) Se o usuário já escolheu 1/2/3, confirmar direto (ETAPA 2)
   try {
-    const text = String(body || '').trim().toLowerCase();
+    const text = String(body || '')
+      .trim()
+      .toLowerCase();
     const m = text.match(/^\s*(?:op(?:ç|c)ao\s*)?([123])\b|^\s*([123])\s*$/);
-    const escolha = m ? (m[1] || m[2]) : null;
+    const escolha = m ? m[1] || m[2] : null;
     if (escolha && from) {
       const { aiScheduleConfirm } = await import('./toolsRuntime.js');
-      const res = await aiScheduleConfirm({ telefone: from.replace(/\D+/g, ''), opcao_escolhida: String(escolha) });
-      await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'agendamento_servico', acao_principal: 'confirmar' }, res });
-      const msg = (res && typeof (res as any).message === 'string') ? (res as any).message : 'Agendamento confirmado!';
+      const res = await aiScheduleConfirm({
+        telefone: from.replace(/\D+/g, ''),
+        opcao_escolhida: String(escolha),
+      });
+      await logAIRoute('ai_route_effective', {
+        from,
+        body,
+        original: decision,
+        effective: { intent: 'agendamento_servico', acao_principal: 'confirmar' },
+        res,
+      });
+      const msg =
+        res && typeof (res as any).message === 'string'
+          ? (res as any).message
+          : 'Agendamento confirmado!';
       return sanitizeAIText(msg);
     }
   } catch {}
@@ -2017,19 +2866,34 @@ async function executeAIAgendamento(decision: any, session?: SessionRecord, body
   const accepted = hasExplicitAcceptance(body || '');
 
   // DETECTAR SELEÇÃO DE HORÁRIO (PRIORIDADE MÁXIMA)
-  const isTimeSelection = body && /^\s*(?:op(?:ç|c)ao\s*)?([123])\b|^\s*([123])\s*$/.test(body.trim());
+  const isTimeSelection =
+    body && /^\s*(?:op(?:ç|c)ao\s*)?([123])\b|^\s*([123])\s*$/.test(body.trim());
 
   if (isTimeSelection) {
     console.log('[DEBUG] SELEÇÃO DE HORÁRIO DETECTADA:', body);
     try {
-      const text = String(body || '').trim().toLowerCase();
+      const text = String(body || '')
+        .trim()
+        .toLowerCase();
       const m = text.match(/^\s*(?:op(?:ç|c)ao\s*)?([123])\b|^\s*([123])\s*$/);
-      const escolha = m ? (m[1] || m[2]) : null;
+      const escolha = m ? m[1] || m[2] : null;
       if (escolha && from) {
         const { aiScheduleConfirm } = await import('./toolsRuntime.js');
-        const res = await aiScheduleConfirm({ telefone: from.replace(/\D+/g, ''), opcao_escolhida: String(escolha) });
-        await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'agendamento_servico', acao_principal: 'confirmar_horario' }, res });
-        const msg = (res && typeof (res as any).message === 'string') ? (res as any).message : 'Agendamento confirmado!';
+        const res = await aiScheduleConfirm({
+          telefone: from.replace(/\D+/g, ''),
+          opcao_escolhida: String(escolha),
+        });
+        await logAIRoute('ai_route_effective', {
+          from,
+          body,
+          original: decision,
+          effective: { intent: 'agendamento_servico', acao_principal: 'confirmar_horario' },
+          res,
+        });
+        const msg =
+          res && typeof (res as any).message === 'string'
+            ? (res as any).message
+            : 'Agendamento confirmado!';
         return sanitizeAIText(msg);
       }
     } catch (e) {
@@ -2037,43 +2901,55 @@ async function executeAIAgendamento(decision: any, session?: SessionRecord, body
     }
   }
 
-
   // GATE: exigir orçamento entregue antes de prosseguir com agendamento (ETAPA 1)
   try {
-    const hasQuoteDeliveredGate = !!((session as any)?.state?.orcamento_entregue);
+    const hasQuoteDeliveredGate = !!(session as any)?.state?.orcamento_entregue;
     if (!hasQuoteDeliveredGate) {
       return 'Vamos primeiro finalizar o orçamento para seguir com o agendamento. Posso te passar os valores?';
     }
   } catch {}
 
   // DETECTAR SE ESTAMOS COLETANDO DADOS PESSOAIS
-  const isPersonalDataCollection = accepted && body && (
+  const isPersonalDataCollection =
+    accepted &&
+    body &&
     // Padrões de nome e endereço juntos (múltiplas linhas)
-    /^[A-Za-zÀ-ÿ\s]{3,50}\s*\n\s*[A-Za-zÀ-ÿ0-9\s,.-]{10,}/.test(body.trim()) ||
-    // Padrões específicos de dados pessoais
-    /(nome|endereço|endereco|rua|avenida|av\.|r\.|cep|cpf|email|@)/i.test(body) ||
-    // Padrão de CEP (8 dígitos)
-    /\b\d{5}-?\d{3}\b/.test(body) ||
-    // Padrão de CPF (11 dígitos)
-    /\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/.test(body) ||
-    // Padrão de e-mail
-    /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/.test(body)
-  );
+    (/^[A-Za-zÀ-ÿ\s]{3,50}\s*\n\s*[A-Za-zÀ-ÿ0-9\s,.-]{10,}/.test(body.trim()) ||
+      // Padrões específicos de dados pessoais
+      /(nome|endereço|endereco|rua|avenida|av\.|r\.|cep|cpf|email|@)/i.test(body) ||
+      // Padrão de CEP (8 dígitos)
+      /\b\d{5}-?\d{3}\b/.test(body) ||
+      // Padrão de CPF (11 dígitos)
+      /\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/.test(body) ||
+      // Padrão de e-mail
+      /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/.test(body));
 
   if (accepted && body) {
     // Extração melhorada de dados pessoais
-    const lines = body.split('\n').map(l => l.trim()).filter(l => l);
+    const lines = body
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l);
     const novo: any = { ...dc };
 
     // Se são múltiplas linhas, primeira é nome, segunda é endereço
     if (lines.length >= 2 && !novo.nome && !novo.endereco) {
       novo.nome = lines[0];
       novo.endereco = lines[1];
-      console.log('[AGENDAMENTO DEBUG] Dados extraídos - Nome:', novo.nome, 'Endereço:', novo.endereco);
+      console.log(
+        '[AGENDAMENTO DEBUG] Dados extraídos - Nome:',
+        novo.nome,
+        'Endereço:',
+        novo.endereco
+      );
     } else {
       // Extração por padrões
-      const nameMatch = body.match(/(?:meu|minha)\s+nome\s*(?:é|eh|:)?\s*([^.,\n\r]{3,80})/i) || body.match(/\bnome\s*(?:é|eh|:)?\s*([^.,\n\r]{3,80})/i);
-      const addrMatch = body.match(/(?:meu\s+)?endere[cç]o\s*(?:é|eh|:)?\s*([^\n\r]{6,160})/i) || body.match(/\bend\.?\s*:?\s*([^\n\r]{6,160})/i);
+      const nameMatch =
+        body.match(/(?:meu|minha)\s+nome\s*(?:é|eh|:)?\s*([^.,\n\r]{3,80})/i) ||
+        body.match(/\bnome\s*(?:é|eh|:)?\s*([^.,\n\r]{3,80})/i);
+      const addrMatch =
+        body.match(/(?:meu\s+)?endere[cç]o\s*(?:é|eh|:)?\s*([^\n\r]{6,160})/i) ||
+        body.match(/\bend\.?\s*:?\s*([^\n\r]{6,160})/i);
       const emailMatch = body.match(/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/);
       const cpfMatch = body.match(/(\d{3}\.?\d{3}\.?\d{3}-?\d{2})/);
 
@@ -2087,7 +2963,10 @@ async function executeAIAgendamento(decision: any, session?: SessionRecord, body
       dc = novo;
       if ((session as any)?.id) {
         try {
-          await setSessionState((session as any).id, { ...(session as any).state, dados_coletados: dc });
+          await setSessionState((session as any).id, {
+            ...(session as any).state,
+            dados_coletados: dc,
+          });
           console.log('[AGENDAMENTO DEBUG] Dados salvos na sessão:', dc);
         } catch {}
       }
@@ -2120,18 +2999,39 @@ async function executeAIAgendamento(decision: any, session?: SessionRecord, body
   if (missing.length) {
     const pr = detectPriorityIntent(body || '');
     if (pr === 'reagendamento') {
-      const reply = 'Perfeito! Para reagendar, me informe o número da sua OS (se tiver). Se não tiver, me passe nome, telefone e endereço. Qual a melhor data e horário para você?';
-      await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'reagendamento', acao_principal: 'coletar_dados' }, reply });
+      const reply =
+        'Perfeito! Para reagendar, me informe o número da sua OS (se tiver). Se não tiver, me passe nome, telefone e endereço. Qual a melhor data e horário para você?';
+      await logAIRoute('ai_route_effective', {
+        from,
+        body,
+        original: decision,
+        effective: { intent: 'reagendamento', acao_principal: 'coletar_dados' },
+        reply,
+      });
       return reply;
     }
     if (pr === 'cancelamento') {
-      const reply = 'Tudo certo! Para concluir o cancelamento, me informe o número da sua OS. Se não tiver, me passe nome, telefone e endereço que localizo seu atendimento para cancelar.';
-      await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'cancelamento', acao_principal: 'coletar_dados' }, reply });
+      const reply =
+        'Tudo certo! Para concluir o cancelamento, me informe o número da sua OS. Se não tiver, me passe nome, telefone e endereço que localizo seu atendimento para cancelar.';
+      await logAIRoute('ai_route_effective', {
+        from,
+        body,
+        original: decision,
+        effective: { intent: 'cancelamento', acao_principal: 'coletar_dados' },
+        reply,
+      });
       return reply;
     }
     if (pr === 'instalacao') {
-      const reply = 'Legal! Para a instalação, preciso de: equipamento, tipo (embutido ou bancada), local exato de instalação, voltagem (127V/220V), distância do ponto de gás/energia e se já há fixação/suportes. Pode me passar esses dados?';
-      await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'instalacao', acao_principal: 'coletar_dados' }, reply });
+      const reply =
+        'Legal! Para a instalação, preciso de: equipamento, tipo (embutido ou bancada), local exato de instalação, voltagem (127V/220V), distância do ponto de gás/energia e se já há fixação/suportes. Pode me passar esses dados?';
+      await logAIRoute('ai_route_effective', {
+        from,
+        body,
+        original: decision,
+        effective: { intent: 'instalacao', acao_principal: 'coletar_dados' },
+        reply,
+      });
       return reply;
     }
     const list = missing.join(', ');
@@ -2163,13 +3063,32 @@ async function executeAIAgendamento(decision: any, session?: SessionRecord, body
     const nome = dc?.nome || telefone || 'Cliente';
     const endereco = dc?.endereco || '';
     const equipamento = eqCombined || 'equipamento';
-    const problema = probCombined || (body || 'problema não especificado');
-    const res = await aiScheduleStart({ nome, endereco, equipamento, problema, telefone, urgente: false });
-    await logAIRoute('ai_route_effective', { from, body, original: decision, effective: { intent: 'agendamento_servico', acao_principal: 'oferecer_horarios' }, res });
-    const msg = (res && typeof (res as any).message === 'string') ? (res as any).message : (decision.resposta_sugerida || 'Tenho estas opções de horário. Qual prefere?');
+    const problema = probCombined || body || 'problema não especificado';
+    const res = await aiScheduleStart({
+      nome,
+      endereco,
+      equipamento,
+      problema,
+      telefone,
+      urgente: false,
+    });
+    await logAIRoute('ai_route_effective', {
+      from,
+      body,
+      original: decision,
+      effective: { intent: 'agendamento_servico', acao_principal: 'oferecer_horarios' },
+      res,
+    });
+    const msg =
+      res && typeof (res as any).message === 'string'
+        ? (res as any).message
+        : decision.resposta_sugerida || 'Tenho estas opções de horário. Qual prefere?';
     return sanitizeAIText(msg);
   } catch (e) {
-    return decision.resposta_sugerida || 'Vou verificar a disponibilidade para agendamento. Um momento...';
+    return (
+      decision.resposta_sugerida ||
+      'Vou verificar a disponibilidade para agendamento. Um momento...'
+    );
   }
 }
 
@@ -2189,7 +3108,9 @@ async function generateAIQuoteResponse(quote: any, decision: any, dados: any): P
       let causasLista: string[] = [];
 
       for (const b of relevant) {
-        const arr = Array.isArray(b.data?.causas_possiveis) ? (b.data!.causas_possiveis as string[]) : [];
+        const arr = Array.isArray(b.data?.causas_possiveis)
+          ? (b.data!.causas_possiveis as string[])
+          : [];
         causasLista.push(...arr);
       }
 
@@ -2231,8 +3152,11 @@ Crie uma resposta natural, empática e profissional para o cliente. Seja conciso
     const response = await chatComplete(
       { provider: 'openai', model: 'gpt-4o-mini', temperature: 0.7 },
       [
-        { role: 'system', content: 'Você é um assistente de atendimento ao cliente empático e profissional.' },
-        { role: 'user', content: prompt }
+        {
+          role: 'system',
+          content: 'Você é um assistente de atendimento ao cliente empático e profissional.',
+        },
+        { role: 'user', content: prompt },
       ]
     );
 
@@ -2243,7 +3167,11 @@ Crie uma resposta natural, empática e profissional para o cliente. Seja conciso
 }
 
 // **FALLBACK: Sistema legado para casos de erro**
-async function legacyRouting(from: string, body: string, session?: SessionRecord): Promise<string | null> {
+async function legacyRouting(
+  from: string,
+  body: string,
+  session?: SessionRecord
+): Promise<string | null> {
   console.log('[AI-ROUTER] 🔄 Usando sistema legado como fallback');
 
   // Implementação simplificada do sistema antigo
@@ -2269,7 +3197,7 @@ async function legacyRouting(from: string, body: string, session?: SessionRecord
         service_type: 'coleta_diagnostico',
         equipment: equipment,
         brand: 'Não informada',
-        problem: 'não está funcionando'
+        problem: 'não está funcionando',
       } as any);
 
       if (quote) {
@@ -2301,13 +3229,27 @@ async function legacyRouting(from: string, body: string, session?: SessionRecord
   return 'Como posso ajudar você hoje?';
 }
 
-async function summarizeToolResult(intent: string, result: any, session?: SessionRecord, lastMessage?: string): Promise<string> {
+async function summarizeToolResult(
+  intent: string,
+  result: any,
+  session?: SessionRecord,
+  lastMessage?: string
+): Promise<string> {
   try {
-    if (result?.found && (result?.value !== undefined || result?.min !== undefined || result?.max !== undefined)) {
+    if (
+      result?.found &&
+      (result?.value !== undefined || result?.min !== undefined || result?.max !== undefined)
+    ) {
       // Marcar na sessão que já entregamos um orçamento (habilita avanço para agendamento)
       try {
         const prev = (session as any)?.state || {};
-        if ((session as any)?.id) await setSessionState((session as any).id, { ...prev, orcamento_entregue: true, last_quote: result, last_quote_ts: Date.now() });
+        if ((session as any)?.id)
+          await setSessionState((session as any).id, {
+            ...prev,
+            orcamento_entregue: true,
+            last_quote: result,
+            last_quote_ts: Date.now(),
+          });
       } catch {}
 
       // Tentar compor texto de possíveis causas a partir dos blocos de conhecimento relevantes
@@ -2318,9 +3260,15 @@ async function summarizeToolResult(intent: string, result: any, session?: Sessio
         const extra = await fetchKnowledgeBlocks();
         const allBlocks = [...botBlocks, ...extra];
         const collected = (session as any)?.state?.dados_coletados || {};
-        const relevant = findRelevantBlocks(allBlocks, lastMessage || '', { equipamento: collected.equipamento, problema: collected.problema, marca: collected.marca });
+        const relevant = findRelevantBlocks(allBlocks, lastMessage || '', {
+          equipamento: collected.equipamento,
+          problema: collected.problema,
+          marca: collected.marca,
+        });
         for (const b of relevant) {
-          const arr = Array.isArray(b.data?.causas_possiveis) ? (b.data!.causas_possiveis as string[]) : [];
+          const arr = Array.isArray(b.data?.causas_possiveis)
+            ? (b.data!.causas_possiveis as string[])
+            : [];
           causasLista.push(...arr);
         }
         // Remover duplicadas e limitar para uma resposta enxuta
@@ -2329,7 +3277,10 @@ async function summarizeToolResult(intent: string, result: any, session?: Sessio
         console.log('[DEBUG] dados coletados:', collected);
         console.log('[DEBUG] blocos relevantes:', relevant.length);
         console.log('[DEBUG] total de blocos disponíveis:', allBlocks.length);
-        console.log('[DEBUG] blocos disponíveis:', allBlocks.map(b => b.key));
+        console.log(
+          '[DEBUG] blocos disponíveis:',
+          allBlocks.map((b) => b.key)
+        );
       } catch (e) {
         console.log('[DEBUG] erro ao buscar causas:', e);
       }
@@ -2338,7 +3289,9 @@ async function summarizeToolResult(intent: string, result: any, session?: Sessio
       let causasFinais: string[] = [];
 
       // Priorizar causas do próprio resultado (para casos específicos como lava-louças)
-      const causasDoResultado = Array.isArray(result?.causas_possiveis) ? result.causas_possiveis : [];
+      const causasDoResultado = Array.isArray(result?.causas_possiveis)
+        ? result.causas_possiveis
+        : [];
 
       if (causasDoResultado.length > 0) {
         causasFinais = causasDoResultado;
@@ -2362,138 +3315,341 @@ async function summarizeToolResult(intent: string, result: any, session?: Sessio
           const equipLower = String(collected.equipamento || result?.equipment || '').toLowerCase();
           const msgLower = String(lastMessage || '').toLowerCase();
           const probLower = String(collected.problema || lastMessage || '').toLowerCase();
-          const equipNorm = equipLower.normalize('NFD').replace(/\p{Diacritic}/gu,'');
-          const msgNorm = msgLower.normalize('NFD').replace(/\p{Diacritic}/gu,'');
-          const probNorm = probLower.normalize('NFD').replace(/\p{Diacritic}/gu,'');
+          const equipNorm = equipLower.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+          const msgNorm = msgLower.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+          const probNorm = probLower.normalize('NFD').replace(/\p{Diacritic}/gu, '');
           if (/adega/.test(equipNorm) || /adega/.test(msgNorm)) {
-            causasFinais = (/não gela|nao gela|parou de esfriar|não esfria|nao esfria/.test(probLower)
-              ? ['Ventilador do evaporador defeituoso','Condensador sujo','Gás refrigerante insuficiente','Compressor com falha','Sensor/termostato (NTC)','Placa eletrônica','Vedação da porta danificada']
+            causasFinais = /não gela|nao gela|parou de esfriar|não esfria|nao esfria/.test(
+              probLower
+            )
+              ? [
+                  'Ventilador do evaporador defeituoso',
+                  'Condensador sujo',
+                  'Gás refrigerante insuficiente',
+                  'Compressor com falha',
+                  'Sensor/termostato (NTC)',
+                  'Placa eletrônica',
+                  'Vedação da porta danificada',
+                ]
               : /não liga|nao liga/.test(probLower)
-              ? ['Alimentação elétrica/fusível','Placa eletrônica','Termostato de segurança','Chave/interruptor']
-              : ['Sistema de refrigeração','Sensor de temperatura (NTC)','Ventilador interno','Placa eletrônica']);
+                ? [
+                    'Alimentação elétrica/fusível',
+                    'Placa eletrônica',
+                    'Termostato de segurança',
+                    'Chave/interruptor',
+                  ]
+                : [
+                    'Sistema de refrigeração',
+                    'Sensor de temperatura (NTC)',
+                    'Ventilador interno',
+                    'Placa eletrônica',
+                  ];
           } else if (/forno.*comercial/.test(equipLower) || /forno.*comercial/.test(msgLower)) {
-            causasFinais = (/não esquenta|nao esquenta|nao aquece|não aquece/.test(probLower)
-              ? ['Resistências queimadas','Termostato defeituoso','Controlador/placa','Relé de potência','Sensor de temperatura']
+            causasFinais = /não esquenta|nao esquenta|nao aquece|não aquece/.test(probLower)
+              ? [
+                  'Resistências queimadas',
+                  'Termostato defeituoso',
+                  'Controlador/placa',
+                  'Relé de potência',
+                  'Sensor de temperatura',
+                ]
               : /não liga|nao liga/.test(probLower)
-              ? ['Alimentação elétrica','Fusível queimado','Chave seletora','Placa de controle']
-              : ['Sistema de aquecimento','Sensor de temperatura','Termostato','Placa eletrônica']);
-          } else if (/fog[aã]o.*industrial/.test(equipLower) || /fog[aã]o.*industrial/.test(msgLower)) {
-            causasFinais = (/não acende|nao acende|sem chama|chama apaga/.test(probLower)
-              ? ['Queimadores sujos/obstruídos','Injetor entupido','Sistema de ignição/acendedor','Válvula/registro','Regulagem de ar insuficiente']
+                ? [
+                    'Alimentação elétrica',
+                    'Fusível queimado',
+                    'Chave seletora',
+                    'Placa de controle',
+                  ]
+                : [
+                    'Sistema de aquecimento',
+                    'Sensor de temperatura',
+                    'Termostato',
+                    'Placa eletrônica',
+                  ];
+          } else if (
+            /fog[aã]o.*industrial/.test(equipLower) ||
+            /fog[aã]o.*industrial/.test(msgLower)
+          ) {
+            causasFinais = /não acende|nao acende|sem chama|chama apaga/.test(probLower)
+              ? [
+                  'Queimadores sujos/obstruídos',
+                  'Injetor entupido',
+                  'Sistema de ignição/acendedor',
+                  'Válvula/registro',
+                  'Regulagem de ar insuficiente',
+                ]
               : /vazamento|vaza/.test(probLower)
-              ? ['Mangueira danificada','Conexões frouxas','Registro com defeito']
-              : /chama amarela|chama fraca/.test(probLower)
-              ? ['Mistura ar/gás desregulada','Injetor inadequado','Entrada de ar obstruída']
-              : ['Queimadores','Injetor','Sistema de ignição','Válvulas/registro']);
-          } else if (/fog[aã]o/.test(equipLower) || /fog[aã]o/.test(msgLower) || /cooktop/.test(equipLower) || /cooktop/.test(msgLower)) {
+                ? ['Mangueira danificada', 'Conexões frouxas', 'Registro com defeito']
+                : /chama amarela|chama fraca/.test(probLower)
+                  ? ['Mistura ar/gás desregulada', 'Injetor inadequado', 'Entrada de ar obstruída']
+                  : ['Queimadores', 'Injetor', 'Sistema de ignição', 'Válvulas/registro'];
+          } else if (
+            /fog[aã]o/.test(equipLower) ||
+            /fog[aã]o/.test(msgLower) ||
+            /cooktop/.test(equipLower) ||
+            /cooktop/.test(msgLower)
+          ) {
             // FOGÃO DOMÉSTICO (a gás, elétrico, indução)
-            causasFinais = (/não acende|nao acende|sem chama|chama apaga/.test(probLower)
-              ? ['Queimador entupido ou sujo','Válvula de segurança com defeito','Sistema de ignição/acendedor','Registro do gás','Mangueira ou conexão']
+            causasFinais = /não acende|nao acende|sem chama|chama apaga/.test(probLower)
+              ? [
+                  'Queimador entupido ou sujo',
+                  'Válvula de segurança com defeito',
+                  'Sistema de ignição/acendedor',
+                  'Registro do gás',
+                  'Mangueira ou conexão',
+                ]
               : /vazamento|vaza/.test(probLower)
-              ? ['Mangueira danificada','Conexões frouxas','Registro com defeito','Válvula com problema']
-              : /chama amarela|chama fraca/.test(probLower)
-              ? ['Queimador sujo','Mistura ar/gás desregulada','Entrada de ar obstruída','Bico injetor']
-              : /não esquenta|nao esquenta|forno/.test(probLower)
-              ? ['Queimador do forno entupido','Termostato com defeito','Válvula do forno','Sistema de ignição do forno']
-              : ['Queimador entupido','Válvula com defeito','Sistema de ignição','Registro do gás']);
-          } else if (/lava.*lou[çc]a|lava.*prato/.test(equipLower) || /lava.*lou[çc]a|lava.*prato/.test(msgLower)) {
+                ? [
+                    'Mangueira danificada',
+                    'Conexões frouxas',
+                    'Registro com defeito',
+                    'Válvula com problema',
+                  ]
+                : /chama amarela|chama fraca/.test(probLower)
+                  ? [
+                      'Queimador sujo',
+                      'Mistura ar/gás desregulada',
+                      'Entrada de ar obstruída',
+                      'Bico injetor',
+                    ]
+                  : /não esquenta|nao esquenta|forno/.test(probLower)
+                    ? [
+                        'Queimador do forno entupido',
+                        'Termostato com defeito',
+                        'Válvula do forno',
+                        'Sistema de ignição do forno',
+                      ]
+                    : [
+                        'Queimador entupido',
+                        'Válvula com defeito',
+                        'Sistema de ignição',
+                        'Registro do gás',
+                      ];
+          } else if (
+            /lava.*lou[çc]a|lava.*prato/.test(equipLower) ||
+            /lava.*lou[çc]a|lava.*prato/.test(msgLower)
+          ) {
             // LAVA-LOUÇAS
-            causasFinais = (/não lava|nao lava|não limpa|nao limpa|suja/.test(probLower)
-              ? ['Filtro entupido','Bomba de água com defeito','Braços aspersores obstruídos','Válvula de entrada de água','Sensor de turbidez']
+            causasFinais = /não lava|nao lava|não limpa|nao limpa|suja/.test(probLower)
+              ? [
+                  'Filtro entupido',
+                  'Bomba de água com defeito',
+                  'Braços aspersores obstruídos',
+                  'Válvula de entrada de água',
+                  'Sensor de turbidez',
+                ]
               : /não enche|nao enche|sem água|falta água/.test(probLower)
-              ? ['Válvula de entrada de água','Filtro de entrada entupido','Pressão de água insuficiente','Sensor de nível']
-              : /não drena|nao drena|água parada|não esvazia/.test(probLower)
-              ? ['Bomba de drenagem','Filtro de drenagem entupido','Mangueira de saída obstruída','Válvula de drenagem']
-              : /barulho|ruído|vibra/.test(probLower)
-              ? ['Bomba de água','Rolamentos da bomba','Braços aspersores soltos','Base desnivelada']
-              : ['Filtro entupido','Bomba de água','Braços aspersores','Válvula de entrada']);
-          } else if (/geladeira|refrigerador|freezer/.test(equipLower) || /geladeira|refrigerador|freezer/.test(msgLower)) {
+                ? [
+                    'Válvula de entrada de água',
+                    'Filtro de entrada entupido',
+                    'Pressão de água insuficiente',
+                    'Sensor de nível',
+                  ]
+                : /não drena|nao drena|água parada|não esvazia/.test(probLower)
+                  ? [
+                      'Bomba de drenagem',
+                      'Filtro de drenagem entupido',
+                      'Mangueira de saída obstruída',
+                      'Válvula de drenagem',
+                    ]
+                  : /barulho|ruído|vibra/.test(probLower)
+                    ? [
+                        'Bomba de água',
+                        'Rolamentos da bomba',
+                        'Braços aspersores soltos',
+                        'Base desnivelada',
+                      ]
+                    : [
+                        'Filtro entupido',
+                        'Bomba de água',
+                        'Braços aspersores',
+                        'Válvula de entrada',
+                      ];
+          } else if (
+            /geladeira|refrigerador|freezer/.test(equipLower) ||
+            /geladeira|refrigerador|freezer/.test(msgLower)
+          ) {
             // GELADEIRA/REFRIGERADOR
-            causasFinais = (/não gela|nao gela|não esfria|nao esfria|quente/.test(probLower)
-              ? ['Gás refrigerante insuficiente','Compressor com defeito','Termostato','Sensor de temperatura','Condensador sujo']
+            causasFinais = /não gela|nao gela|não esfria|nao esfria|quente/.test(probLower)
+              ? [
+                  'Gás refrigerante insuficiente',
+                  'Compressor com defeito',
+                  'Termostato',
+                  'Sensor de temperatura',
+                  'Condensador sujo',
+                ]
               : /congela demais|muito frio|gela demais/.test(probLower)
-              ? ['Termostato desregulado','Sensor de temperatura','Damper com defeito','Placa eletrônica']
-              : /barulho|ruído|vibra/.test(probLower)
-              ? ['Compressor','Ventilador','Rolamentos','Base desnivelada','Tubulação solta']
-              : /vaza|goteira|água/.test(probLower)
-              ? ['Dreno entupido','Borracha da porta','Evaporador','Sistema de degelo']
-              : ['Termostato','Compressor','Gás refrigerante','Sensor de temperatura']);
-          } else if (/micro.*onda|microonda/.test(equipLower) || /micro.*onda|microonda/.test(msgLower)) {
+                ? [
+                    'Termostato desregulado',
+                    'Sensor de temperatura',
+                    'Damper com defeito',
+                    'Placa eletrônica',
+                  ]
+                : /barulho|ruído|vibra/.test(probLower)
+                  ? [
+                      'Compressor',
+                      'Ventilador',
+                      'Rolamentos',
+                      'Base desnivelada',
+                      'Tubulação solta',
+                    ]
+                  : /vaza|goteira|água/.test(probLower)
+                    ? ['Dreno entupido', 'Borracha da porta', 'Evaporador', 'Sistema de degelo']
+                    : ['Termostato', 'Compressor', 'Gás refrigerante', 'Sensor de temperatura'];
+          } else if (
+            /micro.*onda|microonda/.test(equipLower) ||
+            /micro.*onda|microonda/.test(msgLower)
+          ) {
             // MICRO-ONDAS
-            causasFinais = (/não esquenta|nao esquenta|não aquece|nao aquece/.test(probLower)
-              ? ['Magnetron com defeito','Transformador de alta tensão','Capacitor','Diodo de alta tensão','Fusível']
+            causasFinais = /não esquenta|nao esquenta|não aquece|nao aquece/.test(probLower)
+              ? [
+                  'Magnetron com defeito',
+                  'Transformador de alta tensão',
+                  'Capacitor',
+                  'Diodo de alta tensão',
+                  'Fusível',
+                ]
               : /não liga|nao liga|sem energia/.test(probLower)
-              ? ['Fusível queimado','Transformador','Placa eletrônica','Trava da porta','Micro switch']
-              : /faísca|centelha|arco/.test(probLower)
-              ? ['Guia de ondas','Capa do magnetron','Prato giratório','Restos de comida']
-              : /barulho|ruído/.test(probLower)
-              ? ['Magnetron','Ventilador','Motor do prato','Transformador']
-              : ['Magnetron','Transformador','Fusível','Capacitor']);
-          } else if (/máquina.*lavar|lavadora|tanquinho/.test(equipLower) || /máquina.*lavar|lavadora|tanquinho/.test(msgLower)) {
+                ? [
+                    'Fusível queimado',
+                    'Transformador',
+                    'Placa eletrônica',
+                    'Trava da porta',
+                    'Micro switch',
+                  ]
+                : /faísca|centelha|arco/.test(probLower)
+                  ? ['Guia de ondas', 'Capa do magnetron', 'Prato giratório', 'Restos de comida']
+                  : /barulho|ruído/.test(probLower)
+                    ? ['Magnetron', 'Ventilador', 'Motor do prato', 'Transformador']
+                    : ['Magnetron', 'Transformador', 'Fusível', 'Capacitor'];
+          } else if (
+            /máquina.*lavar|lavadora|tanquinho/.test(equipLower) ||
+            /máquina.*lavar|lavadora|tanquinho/.test(msgLower)
+          ) {
             // MÁQUINA DE LAVAR
-            causasFinais = (/não lava|nao lava|não limpa|nao limpa/.test(probLower)
-              ? ['Bomba de água','Válvula de entrada','Agitador/tambor','Filtro entupido','Sensor de nível']
+            causasFinais = /não lava|nao lava|não limpa|nao limpa/.test(probLower)
+              ? [
+                  'Bomba de água',
+                  'Válvula de entrada',
+                  'Agitador/tambor',
+                  'Filtro entupido',
+                  'Sensor de nível',
+                ]
               : /não enche|nao enche|sem água/.test(probLower)
-              ? ['Válvula de entrada de água','Pressão de água','Filtro de entrada','Sensor de nível']
-              : /não centrifuga|nao centrifuga|não torce|nao torce/.test(probLower)
-              ? ['Motor','Correia','Embreagem','Sensor de desequilíbrio','Placa eletrônica']
-              : /vaza|goteira/.test(probLower)
-              ? ['Borracha da porta','Mangueiras','Bomba de água','Válvulas','Tambor']
-              : /barulho|ruído|vibra/.test(probLower)
-              ? ['Rolamentos','Amortecedores','Base desnivelada','Correia','Motor']
-              : ['Bomba de água','Motor','Válvula de entrada','Sensor de nível']);
-          } else if (/ar.*condicionado|split|central de ar/.test(equipLower) || /ar.*condicionado|split|central de ar/.test(msgLower)) {
+                ? [
+                    'Válvula de entrada de água',
+                    'Pressão de água',
+                    'Filtro de entrada',
+                    'Sensor de nível',
+                  ]
+                : /não centrifuga|nao centrifuga|não torce|nao torce/.test(probLower)
+                  ? ['Motor', 'Correia', 'Embreagem', 'Sensor de desequilíbrio', 'Placa eletrônica']
+                  : /vaza|goteira/.test(probLower)
+                    ? ['Borracha da porta', 'Mangueiras', 'Bomba de água', 'Válvulas', 'Tambor']
+                    : /barulho|ruído|vibra/.test(probLower)
+                      ? ['Rolamentos', 'Amortecedores', 'Base desnivelada', 'Correia', 'Motor']
+                      : ['Bomba de água', 'Motor', 'Válvula de entrada', 'Sensor de nível'];
+          } else if (
+            /ar.*condicionado|split|central de ar/.test(equipLower) ||
+            /ar.*condicionado|split|central de ar/.test(msgLower)
+          ) {
             // AR-CONDICIONADO
-            causasFinais = (/não gela|nao gela|não esfria|nao esfria|quente/.test(probLower)
-              ? ['Gás refrigerante insuficiente','Compressor','Condensador sujo','Filtro sujo','Sensor de temperatura']
+            causasFinais = /não gela|nao gela|não esfria|nao esfria|quente/.test(probLower)
+              ? [
+                  'Gás refrigerante insuficiente',
+                  'Compressor',
+                  'Condensador sujo',
+                  'Filtro sujo',
+                  'Sensor de temperatura',
+                ]
               : /não liga|nao liga/.test(probLower)
-              ? ['Placa eletrônica','Capacitor','Controle remoto','Sensor','Fusível']
-              : /vaza|goteira/.test(probLower)
-              ? ['Dreno entupido','Evaporador','Conexões','Bomba de condensado']
-              : /barulho|ruído/.test(probLower)
-              ? ['Compressor','Ventilador','Rolamentos','Suporte solto']
-              : ['Filtro sujo','Gás refrigerante','Compressor','Placa eletrônica']);
-          } else if (/forno.*elétrico|forno elétrico/.test(equipLower) || /forno.*elétrico|forno elétrico/.test(msgLower)) {
+                ? ['Placa eletrônica', 'Capacitor', 'Controle remoto', 'Sensor', 'Fusível']
+                : /vaza|goteira/.test(probLower)
+                  ? ['Dreno entupido', 'Evaporador', 'Conexões', 'Bomba de condensado']
+                  : /barulho|ruído/.test(probLower)
+                    ? ['Compressor', 'Ventilador', 'Rolamentos', 'Suporte solto']
+                    : ['Filtro sujo', 'Gás refrigerante', 'Compressor', 'Placa eletrônica'];
+          } else if (
+            /forno.*elétrico|forno elétrico/.test(equipLower) ||
+            /forno.*elétrico|forno elétrico/.test(msgLower)
+          ) {
             // FORNO ELÉTRICO
-            causasFinais = (/não esquenta|nao esquenta|não aquece|nao aquece/.test(probLower)
-              ? ['Resistência queimada','Termostato','Sensor de temperatura','Placa eletrônica','Relé']
+            causasFinais = /não esquenta|nao esquenta|não aquece|nao aquece/.test(probLower)
+              ? [
+                  'Resistência queimada',
+                  'Termostato',
+                  'Sensor de temperatura',
+                  'Placa eletrônica',
+                  'Relé',
+                ]
               : /não liga|nao liga/.test(probLower)
-              ? ['Fusível','Placa eletrônica','Trava da porta','Termostato','Fiação']
-              : /esquenta demais|muito quente/.test(probLower)
-              ? ['Termostato desregulado','Sensor de temperatura','Ventilador','Sistema de segurança']
-              : ['Resistência','Termostato','Sensor de temperatura','Placa eletrônica']);
-          } else if (/cooktop.*elétrico|cooktop elétrico|indução/.test(equipLower) || /cooktop.*elétrico|cooktop elétrico|indução/.test(msgLower)) {
+                ? ['Fusível', 'Placa eletrônica', 'Trava da porta', 'Termostato', 'Fiação']
+                : /esquenta demais|muito quente/.test(probLower)
+                  ? [
+                      'Termostato desregulado',
+                      'Sensor de temperatura',
+                      'Ventilador',
+                      'Sistema de segurança',
+                    ]
+                  : ['Resistência', 'Termostato', 'Sensor de temperatura', 'Placa eletrônica'];
+          } else if (
+            /cooktop.*elétrico|cooktop elétrico|indução/.test(equipLower) ||
+            /cooktop.*elétrico|cooktop elétrico|indução/.test(msgLower)
+          ) {
             // COOKTOP ELÉTRICO/INDUÇÃO
-            causasFinais = (/não esquenta|nao esquenta|não aquece|nao aquece/.test(probLower)
-              ? ['Resistência queimada','Placa de indução','Sensor de temperatura','Placa eletrônica','Bobina']
+            causasFinais = /não esquenta|nao esquenta|não aquece|nao aquece/.test(probLower)
+              ? [
+                  'Resistência queimada',
+                  'Placa de indução',
+                  'Sensor de temperatura',
+                  'Placa eletrônica',
+                  'Bobina',
+                ]
               : /não liga|nao liga/.test(probLower)
-              ? ['Placa eletrônica','Touch screen','Sensor de panela','Fusível','Fiação']
-              : /liga sozinho|desliga sozinho/.test(probLower)
-              ? ['Placa eletrônica','Touch screen','Sensor de temperatura','Interferência']
-              : ['Placa eletrônica','Resistência/bobina','Sensor','Touch screen']);
-          } else if (/secadora|máquina.*secar/.test(equipLower) || /secadora|máquina.*secar/.test(msgLower)) {
+                ? ['Placa eletrônica', 'Touch screen', 'Sensor de panela', 'Fusível', 'Fiação']
+                : /liga sozinho|desliga sozinho/.test(probLower)
+                  ? ['Placa eletrônica', 'Touch screen', 'Sensor de temperatura', 'Interferência']
+                  : ['Placa eletrônica', 'Resistência/bobina', 'Sensor', 'Touch screen'];
+          } else if (
+            /secadora|máquina.*secar/.test(equipLower) ||
+            /secadora|máquina.*secar/.test(msgLower)
+          ) {
             // SECADORA
-            causasFinais = (/não seca|nao seca|roupa molhada/.test(probLower)
-              ? ['Resistência queimada','Sensor de umidade','Filtro entupido','Duto obstruído','Termostato']
+            causasFinais = /não seca|nao seca|roupa molhada/.test(probLower)
+              ? [
+                  'Resistência queimada',
+                  'Sensor de umidade',
+                  'Filtro entupido',
+                  'Duto obstruído',
+                  'Termostato',
+                ]
               : /não liga|nao liga/.test(probLower)
-              ? ['Fusível','Placa eletrônica','Trava da porta','Motor','Correia']
-              : /barulho|ruído/.test(probLower)
-              ? ['Rolamentos','Correia','Motor','Tambor desalinhado']
-              : ['Resistência','Sensor de umidade','Filtro','Termostato']);
+                ? ['Fusível', 'Placa eletrônica', 'Trava da porta', 'Motor', 'Correia']
+                : /barulho|ruído/.test(probLower)
+                  ? ['Rolamentos', 'Correia', 'Motor', 'Tambor desalinhado']
+                  : ['Resistência', 'Sensor de umidade', 'Filtro', 'Termostato'];
           }
         } catch {}
       }
 
-      const causasText = causasFinais.length ? `Isso pode ser problema de ${causasFinais.join(', ')}.\n\n` : '';
+      const causasText = causasFinais.length
+        ? `Isso pode ser problema de ${causasFinais.join(', ')}.\n\n`
+        : '';
       console.log('[DEBUG] causas finais usadas:', causasFinais);
       const v = result.value ?? result.min ?? result.max;
       // CORREÇÃO: Removido notes para evitar texto "(Visita técnica padrão...)" na resposta
-      console.log('[DEBUG] HUMANIZAÇÃO COMPLETA: GPT humanizado para saudações + perguntas aleatórias + causas específicas para todos equipamentos + detecção de seleção de horário aplicado');
+      console.log(
+        '[DEBUG] HUMANIZAÇÃO COMPLETA: GPT humanizado para saudações + perguntas aleatórias + causas específicas para todos equipamentos + detecção de seleção de horário aplicado'
+      );
       // Mensagens específicas por tipo de serviço
       try {
         const st = String(result?.service_type || '').toLowerCase();
         console.log('[DEBUG] service_type para formatação:', st);
-        if (st.includes('coleta_diagnostico') || st.includes('coleta') || st === 'coleta_diagnostico') {
+        if (
+          st.includes('coleta_diagnostico') ||
+          st.includes('coleta') ||
+          st === 'coleta_diagnostico'
+        ) {
           // Template específico para coleta + diagnóstico
           return `${causasText}Coletamos, diagnosticamos, consertamos e entregamos em até 5 dias úteis.
 
@@ -2514,7 +3670,9 @@ Gostaria de agendar?`;
           // Prefixar com o equipamento quando reconhecido, para atender expectativas dos testes e dar contexto ao cliente
           let prefix = '';
           try {
-            const eqName = String(((session as any)?.state?.dados_coletados?.equipamento || result?.equipment || '')).toLowerCase();
+            const eqName = String(
+              (session as any)?.state?.dados_coletados?.equipamento || result?.equipment || ''
+            ).toLowerCase();
             if (eqName) prefix = `Para o seu ${eqName}: `;
           } catch {}
           return `${prefix}${causasText}O valor de manutenção fica em R$ ${v},00.\n\nO serviço tem 3 meses de garantia e aceitamos cartão e dividimos também se precisar.\nGostaria de agendar?`;
@@ -2526,12 +3684,16 @@ Gostaria de agendar?`;
       }
     }
     if (intent === 'agendamento' && result?.slots) {
-      const slots = result.slots.slice(0,6).map((s:any)=>`${s.start}-${s.end}`).join(', ');
-      return slots ? `Tenho estes horários: ${slots}. Qual prefere?` : 'Não encontrei horários disponíveis nesta data. Quer tentar outra?';
+      const slots = result.slots
+        .slice(0, 6)
+        .map((s: any) => `${s.start}-${s.end}`)
+        .join(', ');
+      return slots
+        ? `Tenho estes horários: ${slots}. Qual prefere?`
+        : 'Não encontrei horários disponíveis nesta data. Quer tentar outra?';
     }
     if (intent === 'cancelamento' && result?.ok) return 'Agendamento cancelado com sucesso.';
     if (intent === 'status' && result?.ok) return `Status atual: ${result.status}`;
   } catch {}
   return typeof result === 'string' ? result : 'Tudo certo. Posso ajudar em algo mais?';
 }
-

--- a/webhook-ai/src/services/flowEngine.ts
+++ b/webhook-ai/src/services/flowEngine.ts
@@ -2,7 +2,7 @@ import { supabase } from './supabase.js';
 import { getActiveBot, getTemplates, renderTemplate } from './botConfig.js';
 import { sendText } from './whatsapp.js';
 
-async function resolveContextVars(to: string){
+async function resolveContextVars(to: string) {
   const phone = to;
   let name = '';
   try {
@@ -27,7 +27,7 @@ async function resolveContextVars(to: string){
       if (so?.client_name) name = so.client_name;
     }
   } catch {}
-  return { phone, contact: phone, name } as Record<string,string>;
+  return { phone, contact: phone, name } as Record<string, string>;
 }
 
 export async function tryHandleByFlows(to: string, message: string) {
@@ -43,7 +43,10 @@ export async function tryHandleByFlows(to: string, message: string) {
 
   // Match simples por keyword
   const lower = message.toLowerCase();
-  const match = flows.find((f: any) => (f.trigger?.type === 'keyword') && lower.includes(String(f.trigger?.value || '').toLowerCase()));
+  const match = flows.find(
+    (f: any) =>
+      f.trigger?.type === 'keyword' && lower.includes(String(f.trigger?.value || '').toLowerCase())
+  );
   if (!match) return false;
 
   // MVP+: primeira ação: send_template ou execute_tool
@@ -55,8 +58,10 @@ export async function tryHandleByFlows(to: string, message: string) {
     const tpl = templates.find((t: any) => t.key === step.params?.key);
     if (!tpl) return false;
     // Suporte opcional a variáveis do template
-    let vars: Record<string,string> = {};
-    try { if (step.params?.vars) vars = JSON.parse(String(step.params.vars)); } catch {}
+    let vars: Record<string, string> = {};
+    try {
+      if (step.params?.vars) vars = JSON.parse(String(step.params.vars));
+    } catch {}
     const context = await resolveContextVars(to);
     const body = renderTemplate(tpl.content, { ...context, ...vars });
     await sendText(to, body);
@@ -69,7 +74,7 @@ export async function tryHandleByFlows(to: string, message: string) {
       if (!tool) return false;
       let inputStr = String(step.params?.input || '{}');
       // Suporte a placeholders simples
-      const today = new Date().toISOString().slice(0,10);
+      const today = new Date().toISOString().slice(0, 10);
       inputStr = inputStr.replace(/\{\{\s*today\s*\}\}/g, today);
       const ctx = await resolveContextVars(to);
       inputStr = inputStr.replace(/\{\{\s*phone\s*\}\}/g, ctx.phone || '');
@@ -81,9 +86,10 @@ export async function tryHandleByFlows(to: string, message: string) {
       const text = typeof result === 'string' ? result : 'Ação executada.';
       await sendText(to, text);
       return true;
-    } catch { return false; }
+    } catch {
+      return false;
+    }
   }
 
   return false;
 }
-

--- a/webhook-ai/src/services/intentRegistry.ts
+++ b/webhook-ai/src/services/intentRegistry.ts
@@ -1,8 +1,7 @@
 import { supabase } from './supabase.js';
 
-export async function getIntents(){
+export async function getIntents() {
   const { data, error } = await supabase.from('bot_intents').select('*').order('name');
   if (error) return [];
   return data || [];
 }
-

--- a/webhook-ai/src/services/intentRouter.ts
+++ b/webhook-ai/src/services/intentRouter.ts
@@ -56,4 +56,3 @@ function looksLikeConfirmation(body: any): boolean {
   const txt = extractText(body).toLowerCase();
   return txt.includes('confirmo') || txt.includes('confirmar agendamento');
 }
-

--- a/webhook-ai/src/services/llmClient.ts
+++ b/webhook-ai/src/services/llmClient.ts
@@ -39,10 +39,10 @@ async function openaiComplete(options: ChatOptions, messages: ChatMessage[]): Pr
   const resp = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
-      'Authorization': `Bearer ${apiKey}`,
-      'Content-Type': 'application/json'
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
     },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   });
   if (!resp.ok) {
     const txt = await resp.text();
@@ -56,11 +56,13 @@ async function openaiComplete(options: ChatOptions, messages: ChatMessage[]): Pr
 async function anthropicComplete(options: ChatOptions, messages: ChatMessage[]): Promise<string> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error('ANTHROPIC_API_KEY not set');
-  const systemMsg = messages.find(m=>m.role==='system')?.content || '';
-  const userAssistantMsgs = messages.filter(m=>m.role!=='system').map(m=>({
-    role: m.role as 'user'|'assistant',
-    content: m.content
-  }));
+  const systemMsg = messages.find((m) => m.role === 'system')?.content || '';
+  const userAssistantMsgs = messages
+    .filter((m) => m.role !== 'system')
+    .map((m) => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    }));
   const body = {
     model: options.model || 'claude-sonnet-4',
     system: systemMsg,
@@ -73,9 +75,9 @@ async function anthropicComplete(options: ChatOptions, messages: ChatMessage[]):
     headers: {
       'x-api-key': apiKey,
       'anthropic-version': '2023-06-01',
-      'content-type': 'application/json'
+      'content-type': 'application/json',
     },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   });
   if (!resp.ok) {
     const txt = await resp.text();
@@ -86,17 +88,24 @@ async function anthropicComplete(options: ChatOptions, messages: ChatMessage[]):
   return out || '';
 }
 
-export function buildSystemPrompt(basePrompt?: string, contextBlocks?: Array<{key:string;description?:string;variables?:Record<string,string>}>): string {
+export function buildSystemPrompt(
+  basePrompt?: string,
+  contextBlocks?: Array<{ key: string; description?: string; variables?: Record<string, string> }>
+): string {
   const parts: string[] = [];
-  parts.push(basePrompt || 'Você é um assistente brasileiro da Fix Fogões. Seja natural, amigável e genuinamente humano! 🇧🇷\n\n' +
-    'Converse como você conversaria com um amigo - use "oi", "e aí", "nossa", "que chato isso mesmo!". Quando alguém te cumprimentar, responda como uma pessoa real faria.\n\n' +
-    'Seu trabalho é ajudar com equipamentos domésticos, mas faça isso de forma natural e empática. Varie suas respostas, seja espontâneo e mostre que você realmente se importa com o problema da pessoa.\n\n' +
-    'Não seja robótico - seja você mesmo! O GPT que você é já sabe como ser natural. 😊');
+  parts.push(
+    basePrompt ||
+      'Você é um assistente brasileiro da Fix Fogões. Seja natural, amigável e genuinamente humano! 🇧🇷\n\n' +
+        'Converse como você conversaria com um amigo - use "oi", "e aí", "nossa", "que chato isso mesmo!". Quando alguém te cumprimentar, responda como uma pessoa real faria.\n\n' +
+        'Seu trabalho é ajudar com equipamentos domésticos, mas faça isso de forma natural e empática. Varie suas respostas, seja espontâneo e mostre que você realmente se importa com o problema da pessoa.\n\n' +
+        'Não seja robótico - seja você mesmo! O GPT que você é já sabe como ser natural. 😊'
+  );
   if (contextBlocks && contextBlocks.length) {
-    const ctx = contextBlocks.map(b=>`[${b.key}] ${b.description || ''}`.trim()).join('\n');
+    const ctx = contextBlocks.map((b) => `[${b.key}] ${b.description || ''}`.trim()).join('\n');
     parts.push('Contextos relevantes:\n' + ctx);
   }
-  parts.push('Regras: 1) Só prometa o que o sistema permite. 2) Se faltar dado, peça educadamente. 3) Nunca invente preços fora do mecanismo de orçamento. 4) Responda em pt-BR. 5) NUNCA peça dados pessoais (nome, telefone, endereço, CPF) antes do cliente aceitar explicitamente o orçamento.');
+  parts.push(
+    'Regras: 1) Só prometa o que o sistema permite. 2) Se faltar dado, peça educadamente. 3) Nunca invente preços fora do mecanismo de orçamento. 4) Responda em pt-BR. 5) NUNCA peça dados pessoais (nome, telefone, endereço, CPF) antes do cliente aceitar explicitamente o orçamento.'
+  );
   return parts.join('\n\n');
 }
-

--- a/webhook-ai/src/services/modules/confirmacaoAgendamento.ts
+++ b/webhook-ai/src/services/modules/confirmacaoAgendamento.ts
@@ -17,14 +17,14 @@ export async function processConfirmation(body: any) {
       address: canonical.address,
       item,
       attendanceType: item.serviceAttendanceType || canonical.attendanceType,
-      description: item.clientDescription || canonical.description || ''
+      description: item.clientDescription || canonical.description || '',
     });
 
     // Aplicar regras de custo
     await applyCostRules(orderId, {
       attendanceType: item.serviceAttendanceType || canonical.attendanceType,
       itemValue: item.serviceValue,
-      mode: 'on_create'
+      mode: 'on_create',
     });
 
     // Criar evento de agenda
@@ -34,7 +34,7 @@ export async function processConfirmation(body: any) {
         end: canonical.scheduling.chosen.end,
         technicianId: canonical.scheduling.chosen.technicianId,
         address: canonical.address?.full,
-        description: item.clientDescription || canonical.description || ''
+        description: item.clientDescription || canonical.description || '',
       });
       created.push({ orderId, eventId });
     } else {
@@ -45,4 +45,3 @@ export async function processConfirmation(body: any) {
   // 3) Retornar algo para logs externos
   return { ok: true, created };
 }
-

--- a/webhook-ai/src/services/modules/faq.ts
+++ b/webhook-ai/src/services/modules/faq.ts
@@ -21,9 +21,9 @@ export async function processFAQ(body: any) {
   }
 
   // Padrão caso não haja template
-  const fallback = 'Como posso ajudar? Opções:\n1) Orçamento\n2) Status de Ordem\n3) Garantia\n4) Falar com humano';
+  const fallback =
+    'Como posso ajudar? Opções:\n1) Orçamento\n2) Status de Ordem\n3) Garantia\n4) Falar com humano';
   await sendText(to, fallback);
   await logOutbound(to, fallback);
   return { ok: true, template: 'default' };
 }
-

--- a/webhook-ai/src/services/modules/feedback.ts
+++ b/webhook-ai/src/services/modules/feedback.ts
@@ -5,7 +5,7 @@ import { logInbound, logOutbound } from '../conversation.js';
 export async function processFeedback(body: any) {
   const to = extractSenderPhone(body);
   if (!to) return { ok: false };
-  await logInbound(to, (body?.entry?.[0]?.changes?.[0]?.value?.messages?.[0]?.text?.body) || '');
+  await logInbound(to, body?.entry?.[0]?.changes?.[0]?.value?.messages?.[0]?.text?.body || '');
 
   const templates = await getTemplates();
   const tpl = templates.find((t: any) => t.key === 'feedback_request');
@@ -21,4 +21,3 @@ export async function processFeedback(body: any) {
   await logOutbound(to, fallback);
   return { ok: true, template: 'default' };
 }
-

--- a/webhook-ai/src/services/modules/garantia.ts
+++ b/webhook-ai/src/services/modules/garantia.ts
@@ -6,33 +6,38 @@ import { logInbound, logOutbound } from '../conversation.js';
 export async function processGarantia(body: any) {
   const to = extractSenderPhone(body);
   if (!to) return { ok: false, reason: 'no_phone' };
-  await logInbound(to, (body?.entry?.[0]?.changes?.[0]?.value?.messages?.[0]?.text?.body) || '');
+  await logInbound(to, body?.entry?.[0]?.changes?.[0]?.value?.messages?.[0]?.text?.body || '');
 
   // TODO: extrair número de OS do texto; por ora, pega última OS do cliente
   const { data } = await supabase
     .from('service_orders')
-    .select('id, order_number, warranty_period, warranty_start_date, warranty_end_date, warranty_terms, created_at')
+    .select(
+      'id, order_number, warranty_period, warranty_start_date, warranty_end_date, warranty_terms, created_at'
+    )
     .order('created_at', { ascending: false })
     .limit(1);
 
   if (!data || data.length === 0) {
-    await sendText(to, 'Não encontrei uma ordem para verificar garantia. Me informe o número da OS (ex.: OS #123).');
+    await sendText(
+      to,
+      'Não encontrei uma ordem para verificar garantia. Me informe o número da OS (ex.: OS #123).'
+    );
     return { ok: true, found: 0 };
   }
 
   const os = data[0];
-  const msg = `Garantia da ${os.order_number || os.id.slice(0,8)}:\n- Período: ${os.warranty_period || 3} meses\n- Início: ${fmt(os.warranty_start_date) || fmt(os.created_at)}\n- Término: ${fmt(os.warranty_end_date)}\nCondições: ${os.warranty_terms || 'Conforme termos padrão da oficina.'}`;
+  const msg = `Garantia da ${os.order_number || os.id.slice(0, 8)}:\n- Período: ${os.warranty_period || 3} meses\n- Início: ${fmt(os.warranty_start_date) || fmt(os.created_at)}\n- Término: ${fmt(os.warranty_end_date)}\nCondições: ${os.warranty_terms || 'Conforme termos padrão da oficina.'}`;
 
   // Tentar template 'warranty_info'
   const templates = await getTemplates();
   const tpl = templates.find((t: any) => t.key === 'warranty_info');
   if (tpl?.content) {
     const bodyTxt = renderTemplate(tpl.content, {
-      os: os.order_number || os.id.slice(0,8),
+      os: os.order_number || os.id.slice(0, 8),
       period: String(os.warranty_period || 3),
       start: fmt(os.warranty_start_date) || fmt(os.created_at),
       end: fmt(os.warranty_end_date),
-      terms: os.warranty_terms || 'Conforme termos padrão da oficina.'
+      terms: os.warranty_terms || 'Conforme termos padrão da oficina.',
     });
     await sendText(to, bodyTxt);
     await logOutbound(to, bodyTxt);
@@ -44,5 +49,6 @@ export async function processGarantia(body: any) {
   return { ok: true, template: 'default' };
 }
 
-function fmt(s?: string | null) { return s ? new Date(s).toLocaleDateString('pt-BR') : ''; }
-
+function fmt(s?: string | null) {
+  return s ? new Date(s).toLocaleDateString('pt-BR') : '';
+}

--- a/webhook-ai/src/services/orchestrator.ts
+++ b/webhook-ai/src/services/orchestrator.ts
@@ -18,7 +18,7 @@ export async function applyCostRules(serviceOrderId: string, input: CostInput) {
     } else if (type === 'coleta_conserto') {
       // final_cost = total, initial_cost = 50%
       if (val && val > 0) {
-        const initial = round2((val * 0.5));
+        const initial = round2(val * 0.5);
         await updateOrder(serviceOrderId, { initial_cost: initial, final_cost: val });
       }
     } else if (type === 'em_domicilio') {
@@ -53,17 +53,25 @@ async function updateOrder(id: string, patch: Record<string, any>) {
 }
 
 async function getInitial(id: string): Promise<number> {
-  const { data } = await supabase.from('service_orders').select('initial_cost').eq('id', id).single();
+  const { data } = await supabase
+    .from('service_orders')
+    .select('initial_cost')
+    .eq('id', id)
+    .single();
   return toNumber(data?.initial_cost) || 0;
 }
 
 function toNumber(n: any): number | null {
   if (n === null || n === undefined) return null;
   if (typeof n === 'number') return n;
-  const s = String(n).replace(/[^0-9.,]/g, '').replace('.', '').replace(',', '.');
+  const s = String(n)
+    .replace(/[^0-9.,]/g, '')
+    .replace('.', '')
+    .replace(',', '.');
   const v = Number(s);
   return isNaN(v) ? null : v;
 }
 
-function round2(n: number) { return Math.round(n * 100) / 100; }
-
+function round2(n: number) {
+  return Math.round(n * 100) / 100;
+}

--- a/webhook-ai/src/services/orders.ts
+++ b/webhook-ai/src/services/orders.ts
@@ -2,18 +2,31 @@ import { supabase } from './supabase.js';
 import { z } from 'zod';
 
 const UpsertOrderInput = z.object({
-  client: z.object({ name: z.string().optional(), phone: z.string().optional(), id: z.string().nullable().optional() }),
-  address: z.object({ full: z.string().nullable().optional(), city: z.string().nullable().optional(), state: z.string().nullable().optional(), zip: z.string().nullable().optional() }).optional(),
+  client: z.object({
+    name: z.string().optional(),
+    phone: z.string().optional(),
+    id: z.string().nullable().optional(),
+  }),
+  address: z
+    .object({
+      full: z.string().nullable().optional(),
+      city: z.string().nullable().optional(),
+      state: z.string().nullable().optional(),
+      zip: z.string().nullable().optional(),
+    })
+    .optional(),
   item: z.object({
     equipmentType: z.string().optional().default(''),
     equipmentModel: z.string().nullable().optional(),
     equipmentSerial: z.string().nullable().optional(),
     clientDescription: z.string().optional().default(''),
-    serviceAttendanceType: z.enum(['em_domicilio','coleta_conserto','coleta_diagnostico']).optional(),
-    serviceValue: z.string().optional().default('')
+    serviceAttendanceType: z
+      .enum(['em_domicilio', 'coleta_conserto', 'coleta_diagnostico'])
+      .optional(),
+    serviceValue: z.string().optional().default(''),
   }),
-  attendanceType: z.enum(['em_domicilio','coleta_conserto','coleta_diagnostico']).optional(),
-  description: z.string().optional().default('')
+  attendanceType: z.enum(['em_domicilio', 'coleta_conserto', 'coleta_diagnostico']).optional(),
+  description: z.string().optional().default(''),
 });
 
 export async function upsertServiceOrder(input: z.infer<typeof UpsertOrderInput>): Promise<string> {
@@ -26,13 +39,14 @@ export async function upsertServiceOrder(input: z.infer<typeof UpsertOrderInput>
     equipment_type: data.item.equipmentType || '',
     equipment_model: data.item.equipmentModel || null,
     equipment_serial: data.item.equipmentSerial || null,
-    service_attendance_type: data.item.serviceAttendanceType || data.attendanceType || 'em_domicilio',
+    service_attendance_type:
+      data.item.serviceAttendanceType || data.attendanceType || 'em_domicilio',
     pickup_address: data.address?.full || null,
     pickup_city: data.address?.city || null,
     pickup_state: data.address?.state || null,
     pickup_zip_code: data.address?.zip || null,
     status: 'scheduled',
-    created_at: new Date().toISOString()
+    created_at: new Date().toISOString(),
   };
 
   const { data: inserted, error } = await supabase
@@ -45,7 +59,16 @@ export async function upsertServiceOrder(input: z.infer<typeof UpsertOrderInput>
   return inserted!.id as string;
 }
 
-export async function createCalendarEvent(orderId: string, opts: { start: string; end: string; technicianId?: string | null; address?: string | null; description?: string | null; }) {
+export async function createCalendarEvent(
+  orderId: string,
+  opts: {
+    start: string;
+    end: string;
+    technicianId?: string | null;
+    address?: string | null;
+    description?: string | null;
+  }
+) {
   const event = {
     service_order_id: orderId,
     start_time: opts.start,
@@ -55,10 +78,13 @@ export async function createCalendarEvent(orderId: string, opts: { start: string
     description: opts.description || '',
     client_name: '',
     technician_name: '',
-    status: 'scheduled'
+    status: 'scheduled',
   };
-  const { data, error } = await supabase.from('calendar_events').insert(event).select('id').single();
+  const { data, error } = await supabase
+    .from('calendar_events')
+    .insert(event)
+    .select('id')
+    .single();
   if (error) throw error;
   return data!.id as string;
 }
-

--- a/webhook-ai/src/services/parser/trainingParser.ts
+++ b/webhook-ai/src/services/parser/trainingParser.ts
@@ -10,44 +10,95 @@ export type ParsedBlock = {
 
 const EQUIPAMENTOS = [
   // Fogão / Forno
-  'fogão','fogao',
-  'forno','forno elétrico','forno eletrico','forno a gás','forno a gas','forno de embutir','forno embutir',
+  'fogão',
+  'fogao',
+  'forno',
+  'forno elétrico',
+  'forno eletrico',
+  'forno a gás',
+  'forno a gas',
+  'forno de embutir',
+  'forno embutir',
   // Cooktop
-  'cooktop','cook top','cook-top',
+  'cooktop',
+  'cook top',
+  'cook-top',
   // Micro-ondas
-  'micro-ondas','microondas','micro ondas','forno microondas','forno micro-ondas','forno de microondas',
+  'micro-ondas',
+  'microondas',
+  'micro ondas',
+  'forno microondas',
+  'forno micro-ondas',
+  'forno de microondas',
   // Lava-louças
-  'lava louças','lava-louças','lava louça','lava-louça','lava-louca','lava louca',
-  'lavalouças','lavalouça','lava loucas','lava-loucas','lavaloucas','lavalouca',
+  'lava louças',
+  'lava-louças',
+  'lava louça',
+  'lava-louça',
+  'lava-louca',
+  'lava louca',
+  'lavalouças',
+  'lavalouça',
+  'lava loucas',
+  'lava-loucas',
+  'lavaloucas',
+  'lavalouca',
   // Lava-roupas / Lavadora
-  'lava roupas','lava-roupas','lavadora','lavadora de roupas','máquina de lavar','maquina de lavar','máquina lavar','maquina lavar',
+  'lava roupas',
+  'lava-roupas',
+  'lavadora',
+  'lavadora de roupas',
+  'máquina de lavar',
+  'maquina de lavar',
+  'máquina lavar',
+  'maquina lavar',
   // Lava e seca
-  'lava e seca','lava-seca','lava & seca','lava&seca','lava seca',
+  'lava e seca',
+  'lava-seca',
+  'lava & seca',
+  'lava&seca',
+  'lava seca',
   // Secadora
-  'secadora','secadora de roupas',
+  'secadora',
+  'secadora de roupas',
   // Coifa
-  'coifa','exaustor','depurador',
+  'coifa',
+  'exaustor',
+  'depurador',
   // Adega
-  'adega','adega climatizada','adega de vinhos','adega de vinho'
+  'adega',
+  'adega climatizada',
+  'adega de vinhos',
+  'adega de vinho',
 ];
 
-function guessEquipment(text: string){
+function guessEquipment(text: string) {
   const b = text.toLowerCase();
-  for (const e of EQUIPAMENTOS){ if (b.includes(e)) return e.replace('fogao','fogão'); }
+  for (const e of EQUIPAMENTOS) {
+    if (b.includes(e)) return e.replace('fogao', 'fogão');
+  }
   return undefined;
 }
 
-function extractListAfter(label: RegExp, body: string){
+function extractListAfter(label: RegExp, body: string) {
   const m = body.match(label);
   if (!m) return [];
   const start = m.index! + m[0].length;
   const after = body.slice(start).split(/\n\n|\r\n\r\n/)[0];
-  return after.split(/\n|\r\n/).map(s=>s.replace(/^[-•\s]+/,'').trim()).filter(Boolean);
+  return after
+    .split(/\n|\r\n/)
+    .map((s) => s.replace(/^[-•\s]+/, '').trim())
+    .filter(Boolean);
 }
 
-export function parseTrainingFile(content: string, filename: string): ParsedBlock{
-  const key = path.basename(filename).toLowerCase()
-    .replace(/\s+/g,'_').replace(/[^a-z0-9_]/g,'_').replace(/_+/g,'_').replace(/_txt$/,'');
+export function parseTrainingFile(content: string, filename: string): ParsedBlock {
+  const key = path
+    .basename(filename)
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/_txt$/, '');
   const equipment = guessEquipment(content);
   const sintomas = extractListAfter(/(sintomas|problemas|situações|exemplos):?\s*$/i, content);
   const causas = extractListAfter(/(causas|possíveis causas|hipóteses):?\s*$/i, content);
@@ -58,7 +109,7 @@ export function parseTrainingFile(content: string, filename: string): ParsedBloc
     sintomas: sintomas.length ? sintomas : undefined,
     causas_possiveis: causas.length ? causas : undefined,
     mensagens_base: mensagens.length ? { base: mensagens.join(' ') } : undefined,
-    raw_text: content.slice(0, 4000)
+    raw_text: content.slice(0, 4000),
   };
 
   return { key, type: 'knowledge_block', description: filename, data };
@@ -67,7 +118,7 @@ export function parseTrainingFile(content: string, filename: string): ParsedBloc
 export function parseDirectory(dir: string): ParsedBlock[] {
   const files = fs.readdirSync(dir);
   const out: ParsedBlock[] = [];
-  for (const f of files){
+  for (const f of files) {
     const p = path.join(dir, f);
     const stat = fs.statSync(p);
     if (stat.isDirectory()) continue;
@@ -76,4 +127,3 @@ export function parseDirectory(dir: string): ParsedBlock[] {
   }
   return out;
 }
-

--- a/webhook-ai/src/services/pause.ts
+++ b/webhook-ai/src/services/pause.ts
@@ -7,4 +7,3 @@ export function isGloballyPaused() {
 export function setGlobalPause(p: boolean) {
   pausedGlobal = !!p;
 }
-

--- a/webhook-ai/src/services/payloadAdapters/confirmacaoAdapter.ts
+++ b/webhook-ai/src/services/payloadAdapters/confirmacaoAdapter.ts
@@ -5,35 +5,47 @@ const ItemSchema = z.object({
   equipmentModel: z.string().optional().nullable(),
   equipmentSerial: z.string().optional().nullable(),
   clientDescription: z.string().optional().default(''),
-  serviceAttendanceType: z.enum(['em_domicilio','coleta_conserto','coleta_diagnostico']).optional(),
-  serviceValue: z.string().optional().default('')
+  serviceAttendanceType: z
+    .enum(['em_domicilio', 'coleta_conserto', 'coleta_diagnostico'])
+    .optional(),
+  serviceValue: z.string().optional().default(''),
 });
 
 const CanonicalSchema = z.object({
   client: z.object({
     name: z.string().optional().default(''),
     phone: z.string().optional().default(''),
-    id: z.string().optional().nullable()
+    id: z.string().optional().nullable(),
   }),
-  address: z.object({
-    full: z.string().optional().nullable(),
-    city: z.string().optional().nullable(),
-    state: z.string().optional().nullable(),
-    zip: z.string().optional().nullable()
-  }).optional(),
-  attendanceType: z.enum(['em_domicilio','coleta_conserto','coleta_diagnostico']).optional(),
+  address: z
+    .object({
+      full: z.string().optional().nullable(),
+      city: z.string().optional().nullable(),
+      state: z.string().optional().nullable(),
+      zip: z.string().optional().nullable(),
+    })
+    .optional(),
+  attendanceType: z.enum(['em_domicilio', 'coleta_conserto', 'coleta_diagnostico']).optional(),
   description: z.string().optional(),
   items: z.array(ItemSchema),
-  scheduling: z.object({
-    chosen: z.object({ start: z.string(), end: z.string(), technicianId: z.string().optional().nullable() }).optional(),
-  }).optional(),
+  scheduling: z
+    .object({
+      chosen: z
+        .object({
+          start: z.string(),
+          end: z.string(),
+          technicianId: z.string().optional().nullable(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 export function mapLegacyConfirmation(body: any) {
   const p = body?.payload || body;
   const toItems = () => {
     const items: any[] = [];
-    for (let i=1;i<=5;i++) {
+    for (let i = 1; i <= 5; i++) {
       const eq = p[`equipamento_${i}`] || p[`equipment_${i}`];
       const val = p[`valor_os${i}`] || p[`valor_${i}`];
       if (!eq && !val) continue;
@@ -43,7 +55,7 @@ export function mapLegacyConfirmation(body: any) {
         equipmentSerial: p[`serie_${i}`] || null,
         clientDescription: p[`descricao_${i}`] || p['descricao'] || '',
         serviceAttendanceType: p[`service_attendance_type_${i}`] || p['service_attendance_type'],
-        serviceValue: String(val || '')
+        serviceValue: String(val || ''),
       });
     }
     if (items.length === 0) {
@@ -53,7 +65,7 @@ export function mapLegacyConfirmation(body: any) {
         equipmentSerial: p['serie'] || null,
         clientDescription: p['descricao'] || '',
         serviceAttendanceType: p['service_attendance_type'],
-        serviceValue: String(p['valor_os'] || p['valor'] || '')
+        serviceValue: String(p['valor_os'] || p['valor'] || ''),
       });
     }
     return items;
@@ -63,20 +75,20 @@ export function mapLegacyConfirmation(body: any) {
     client: {
       name: p['nome'] || p['client_name'] || '',
       phone: p['telefone'] || p['client_phone'] || '',
-      id: p['client_id'] || null
+      id: p['client_id'] || null,
     },
     address: {
       full: p['endereco'] || p['pickup_address'] || null,
       city: p['cidade'] || p['pickup_city'] || null,
       state: p['estado'] || p['pickup_state'] || null,
-      zip: p['cep'] || p['pickup_zip_code'] || null
+      zip: p['cep'] || p['pickup_zip_code'] || null,
     },
     attendanceType: p['service_attendance_type'] || p['tipo_servico'] || undefined,
     description: p['descricao'] || p['description'] || undefined,
     items: toItems(),
     scheduling: {
-      chosen: p['chosen_option_id'] ? lookupOption(p, p['chosen_option_id']) : undefined
-    }
+      chosen: p['chosen_option_id'] ? lookupOption(p, p['chosen_option_id']) : undefined,
+    },
   };
   return CanonicalSchema.parse(canonical);
 }
@@ -87,6 +99,9 @@ function lookupOption(p: any, chosen: any) {
   const end = p[`opcao_${chosen}_end`] || p[`opcao_${chosen}_fim`] || p['end_time'];
   const technicianId = p[`opcao_${chosen}_technician_id`] || p['technician_id'] || null;
   if (!start || !end) return undefined;
-  return { start: String(start), end: String(end), technicianId: technicianId ? String(technicianId) : null };
+  return {
+    start: String(start),
+    end: String(end),
+    technicianId: technicianId ? String(technicianId) : null,
+  };
 }
-

--- a/webhook-ai/src/services/policies.ts
+++ b/webhook-ai/src/services/policies.ts
@@ -8,24 +8,40 @@ export type ServicePolicyRow = {
   enabled?: boolean | null;
 };
 
-export function getOfferMessageForServiceType(policies: ServicePolicyRow[], type: ServicePolicyRow['service_type']): string | null {
-  const row = policies.find(p => p.service_type === type && p.enabled !== false);
-  return (row?.offer_message || null);
+export function getOfferMessageForServiceType(
+  policies: ServicePolicyRow[],
+  type: ServicePolicyRow['service_type']
+): string | null {
+  const row = policies.find((p) => p.service_type === type && p.enabled !== false);
+  return row?.offer_message || null;
 }
 
 export async function fetchServicePolicies(): Promise<ServicePolicyRow[]> {
-  const { data, error } = await supabase.from('bot_service_policies').select('*').eq('enabled', true);
+  const { data, error } = await supabase
+    .from('bot_service_policies')
+    .select('*')
+    .eq('enabled', true);
   if (error || !data) return [];
   return data as ServicePolicyRow[];
 }
 
-export function getPreferredServicesForEquipment(policies: ServicePolicyRow[], equipamento?: string): string[] {
+export function getPreferredServicesForEquipment(
+  policies: ServicePolicyRow[],
+  equipamento?: string
+): string[] {
   if (!equipamento) return [];
   const e = equipamento.toLowerCase();
   console.log('[Policies] Analisando equipamento:', equipamento, '→', e);
 
   // Detectar ambiguidade - retorna vazio para forçar pergunta
-  if (e.includes('fogão') && !e.includes('gás') && !e.includes('indução') && !e.includes('elétrico') && !e.includes('comum')) return [];
+  if (
+    e.includes('fogão') &&
+    !e.includes('gás') &&
+    !e.includes('indução') &&
+    !e.includes('elétrico') &&
+    !e.includes('comum')
+  )
+    return [];
   if (e.includes('microondas') && !e.includes('embutido') && !e.includes('bancada')) return [];
   if (e.includes('forno') && !e.includes('embutido') && !e.includes('bancada')) return [];
 
@@ -35,17 +51,21 @@ export function getPreferredServicesForEquipment(policies: ServicePolicyRow[], e
   if (e.includes('microondas') && !e.includes('embutido')) return ['coleta_conserto'];
   if (e.includes('micro-ondas') && !e.includes('embutido')) return ['coleta_conserto'];
   if (e.includes('forno') && e.includes('bancada')) return ['coleta_conserto'];
-  if (e.includes('forno') && e.includes('elétrico') && e.includes('bancada')) return ['coleta_conserto'];
+  if (e.includes('forno') && e.includes('elétrico') && e.includes('bancada'))
+    return ['coleta_conserto'];
 
   // 2. Coleta diagnóstico - equipamentos específicos
-  if (e.includes('fogão') && (e.includes('indução') || e.includes('elétrico'))) return ['coleta_diagnostico'];
+  if (e.includes('fogão') && (e.includes('indução') || e.includes('elétrico')))
+    return ['coleta_diagnostico'];
   // Forno elétrico de embutir = diagnóstico (nunca domicílio)
-  if (e.includes('forno') && e.includes('elétrico') && e.includes('embut')) return ['coleta_diagnostico'];
+  if (e.includes('forno') && e.includes('elétrico') && e.includes('embut'))
+    return ['coleta_diagnostico'];
   if (e.includes('micro-ondas') && e.includes('embutido')) return ['coleta_diagnostico'];
   if (e.includes('microondas') && e.includes('embutido')) return ['coleta_diagnostico'];
   if (e.includes('adega')) return ['coleta_diagnostico'];
   if (e.includes('embutido')) return ['coleta_diagnostico'];
-  if (e.includes('lava') && (e.includes('louça') || e.includes('roupa') || e.includes('seca'))) return ['coleta_diagnostico'];
+  if (e.includes('lava') && (e.includes('louça') || e.includes('roupa') || e.includes('seca')))
+    return ['coleta_diagnostico'];
   if (e.includes('secadora')) return ['coleta_diagnostico'];
   if (e.includes('máquina') && e.includes('lavar')) return ['coleta_diagnostico'];
 
@@ -59,20 +79,23 @@ export function getPreferredServicesForEquipment(policies: ServicePolicyRow[], e
 
   // Fallback: se não encontrou nada específico, tenta matching genérico
   const matches = (row: ServicePolicyRow) => {
-    return (row.equipments || []).some(x => {
+    return (row.equipments || []).some((x) => {
       const equipment = String(x || '').toLowerCase();
       return e.includes(equipment) || equipment.includes(e);
     });
   };
 
-  const order: ServicePolicyRow['service_type'][] = ['coleta_conserto', 'coleta_diagnostico', 'domicilio'];
+  const order: ServicePolicyRow['service_type'][] = [
+    'coleta_conserto',
+    'coleta_diagnostico',
+    'domicilio',
+  ];
   const result: string[] = [];
-  for (const t of order){
-    const rows = policies.filter(p => p.service_type === t && matches(p));
+  for (const t of order) {
+    const rows = policies.filter((p) => p.service_type === t && matches(p));
     if (rows.length) result.push(t);
   }
   const finalResult = Array.from(new Set(result));
   console.log('[Policies] Resultado final:', finalResult);
   return finalResult;
 }
-

--- a/webhook-ai/src/services/quoteLocal.ts
+++ b/webhook-ai/src/services/quoteLocal.ts
@@ -1,30 +1,35 @@
 // Local fallback sem dependência externa
-export type QuoteForm = { equipment: string; brand?: string; description?: string; segment?: string; problemCategory?: string };
+export type QuoteForm = {
+  equipment: string;
+  brand?: string;
+  description?: string;
+  segment?: string;
+  problemCategory?: string;
+};
 
-export function computeLocalQuote(d: QuoteForm){
+export function computeLocalQuote(d: QuoteForm) {
   const base = 350;
-  const segMul = /premium|inox/i.test(d.segment||'') ? 1.2 : 1.0;
+  const segMul = /premium|inox/i.test(d.segment || '') ? 1.2 : 1.0;
   const value = Math.round(base * segMul);
   return {
     title: 'Orçamento estimado (coleta e diagnóstico)',
     priceLabel: `Estimativa: R$ ${value} (desconto 100% do diagnóstico se aprovar o serviço)`,
     value,
-    min: value-50,
-    max: value+150,
+    min: value - 50,
+    max: value + 150,
     details: [
       'Coleta e diagnóstico na bancada',
       'Transporte seguro e retorno instalado',
-      'Se aprovar o serviço, o valor do diagnóstico é abatido 100%'
-    ]
+      'Se aprovar o serviço, o valor do diagnóstico é abatido 100%',
+    ],
   };
 }
 
 export function buildLocalQuoteMessage(form: QuoteForm): string {
   const preview = computeLocalQuote(form);
   if (!preview) return 'Não consegui estimar o orçamento para este serviço.';
-  const bullets = preview.details.map(d=>`- ${d}`).join('\n');
+  const bullets = preview.details.map((d) => `- ${d}`).join('\n');
   const seg = form.segment ? `\nSegmento: ${form.segment}` : '';
   const prob = form.problemCategory ? `\nCategoria do problema: ${form.problemCategory}` : '';
   return `${preview.title}\n\n${preview.priceLabel}\n${seg}${prob}\n\n${bullets}\n\nDeseja agendar?`;
 }
-

--- a/webhook-ai/src/services/sessionStore.ts
+++ b/webhook-ai/src/services/sessionStore.ts
@@ -2,7 +2,7 @@ import { supabase } from './supabase.js';
 
 export type SessionRecord = { id: string; channel: string; peer_id: string; state?: any };
 
-export async function getOrCreateSession(channel: string, peer_id: string): Promise<SessionRecord>{
+export async function getOrCreateSession(channel: string, peer_id: string): Promise<SessionRecord> {
   // try find existing
   const { data: existing } = await supabase
     .from('bot_sessions')
@@ -18,7 +18,7 @@ export async function getOrCreateSession(channel: string, peer_id: string): Prom
   return data as SessionRecord;
 }
 
-export async function setSessionState(session_id: string, state: any){
+export async function setSessionState(session_id: string, state: any) {
   // Merge com estado existente para não perder flags como "greeted"
   try {
     const { data: existing } = await supabase
@@ -35,7 +35,11 @@ export async function setSessionState(session_id: string, state: any){
   }
 }
 
-export async function logMessage(session_id: string, direction: 'in'|'out', body: string, meta?: any){
+export async function logMessage(
+  session_id: string,
+  direction: 'in' | 'out',
+  body: string,
+  meta?: any
+) {
   await supabase.from('bot_messages').insert({ session_id, direction, body, meta: meta || null });
 }
-

--- a/webhook-ai/src/services/supabase.ts
+++ b/webhook-ai/src/services/supabase.ts
@@ -8,15 +8,26 @@ function makeMock() {
   let idCounter = 1;
 
   function matchRows(rows: any[], query: Record<string, any>) {
-    return rows.filter(r => Object.entries(query).every(([k, v]) => r[k] === v));
+    return rows.filter((r) => Object.entries(query).every(([k, v]) => r[k] === v));
   }
 
   function table(name: string) {
     return {
       select(_cols?: string) {
-        const ctx: any = { _name: name, _rows: name === 'bot_sessions' ? sessions : messages, _query: {}, _limit: undefined };
-        ctx.eq = function (k: string, v: any) { this._query[k] = v; return this; };
-        ctx.limit = function (n: number) { this._limit = n; return this; };
+        const ctx: any = {
+          _name: name,
+          _rows: name === 'bot_sessions' ? sessions : messages,
+          _query: {},
+          _limit: undefined,
+        };
+        ctx.eq = function (k: string, v: any) {
+          this._query[k] = v;
+          return this;
+        };
+        ctx.limit = function (n: number) {
+          this._limit = n;
+          return this;
+        };
         ctx.single = async function () {
           let rows = matchRows(this._rows, this._query);
           if (this._limit) rows = rows.slice(0, this._limit);
@@ -27,7 +38,9 @@ function makeMock() {
       },
       insert(payload: any) {
         return {
-          select() { return this; },
+          select() {
+            return this;
+          },
           async single() {
             if (name === 'bot_sessions') {
               const row = { id: String(idCounter++), ...payload };
@@ -39,7 +52,7 @@ function makeMock() {
               return { data: row } as any;
             }
             return { data: null } as any;
-          }
+          },
         };
       },
       update(payload: any) {
@@ -48,12 +61,15 @@ function makeMock() {
             const rows = name === 'bot_sessions' ? sessions : messages;
             let updated: any[] = [];
             for (const r of rows) {
-              if (r[k] === v) { Object.assign(r, payload); updated.push(r); }
+              if (r[k] === v) {
+                Object.assign(r, payload);
+                updated.push(r);
+              }
             }
             return { data: updated } as any;
-          }
+          },
         };
-      }
+      },
     } as any;
   }
 
@@ -70,4 +86,3 @@ if (useMock) {
 }
 
 export const supabase = supabaseImpl;
-

--- a/webhook-ai/src/services/testMode.ts
+++ b/webhook-ai/src/services/testMode.ts
@@ -1,6 +1,9 @@
 let testModeEnabled = false;
 // Permitidos podem ser configurados via env TEST_ALLOWED_DIGITS=4899...,55119... (CSV)
-const envAllowed = (process.env.TEST_ALLOWED_DIGITS || '').split(',').map(s=>s.trim()).filter(Boolean);
+const envAllowed = (process.env.TEST_ALLOWED_DIGITS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
 const allowedDigits = envAllowed.length ? envAllowed : ['48991962111']; // números sem DDI por padrão
 
 function normalizePeerToDigits(peer?: string): string {
@@ -10,11 +13,11 @@ function normalizePeerToDigits(peer?: string): string {
   return digits;
 }
 
-export function isTestModeEnabled(){
+export function isTestModeEnabled() {
   return testModeEnabled;
 }
 
-export function setTestModeEnabled(v: boolean){
+export function setTestModeEnabled(v: boolean) {
   testModeEnabled = !!v;
 }
 
@@ -22,26 +25,25 @@ export function isPeerAllowedForTestMode(peer?: string): boolean {
   const d = normalizePeerToDigits(peer);
   if (!d) return false;
   // aceita igual ao permitido (sem DDI) ou com DDI 55; também aceita endsWith para cobrir wa jid com sufixos
-  for (const base of allowedDigits){
-    const b = base.replace(/\D+/g,'');
+  for (const base of allowedDigits) {
+    const b = base.replace(/\D+/g, '');
     if (!b) continue;
-    if (d === b) return true;         // 4899...
-    if (d === `55${b}`) return true;  // 55 + 4899...
-    if (d.endsWith(b)) return true;   // ...4899... (cobrir variações de jid)
+    if (d === b) return true; // 4899...
+    if (d === `55${b}`) return true; // 55 + 4899...
+    if (d.endsWith(b)) return true; // ...4899... (cobrir variações de jid)
   }
   return false;
 }
 
-export function getTestModeStatus(){
+export function getTestModeStatus() {
   return { enabled: testModeEnabled, allowed: allowedDigits.slice() };
 }
 
 // Utilitário para validar destino em modo de teste
-export function assertSendAllowedInTestMode(to?: string){
+export function assertSendAllowedInTestMode(to?: string) {
   if (!isTestModeEnabled()) return;
   if (!isPeerAllowedForTestMode(to)) {
-    const d = (to||'');
+    const d = to || '';
     throw new Error(`test_mode_blocked: envio bloqueado para ${d}`);
   }
 }
-

--- a/webhook-ai/src/services/toolExecutorByName.ts
+++ b/webhook-ai/src/services/toolExecutorByName.ts
@@ -1,25 +1,47 @@
-import { buildQuote, getAvailability, createAppointment, cancelAppointment, getOrderStatus } from './toolsRuntime.js';
-import { buildQuoteMW, getAvailabilityMW, createAppointmentMW, cancelAppointmentMW, getOrderStatusMW } from './toolsRuntimeMiddleware.js';
+import {
+  buildQuote,
+  getAvailability,
+  createAppointment,
+  cancelAppointment,
+  getOrderStatus,
+} from './toolsRuntime.js';
+import {
+  buildQuoteMW,
+  getAvailabilityMW,
+  createAppointmentMW,
+  cancelAppointmentMW,
+  getOrderStatusMW,
+} from './toolsRuntimeMiddleware.js';
 
 const USE_MIDDLEWARE = (process.env.USE_BOT_MIDDLEWARE || 'false') === 'true';
 
-export async function tryExecuteToolByName(name: string, input: any){
+export async function tryExecuteToolByName(name: string, input: any) {
   const fn = async (n: string, i: any) => {
     if (!USE_MIDDLEWARE) {
       switch (n) {
-        case 'buildQuote': return await buildQuote(i); // remoto padrão
-        case 'getAvailability': return await getAvailability(i);
-        case 'createAppointment': return await createAppointment(i);
-        case 'cancelAppointment': return await cancelAppointment(i);
-        case 'getOrderStatus': return await getOrderStatus(i?.id || i);
+        case 'buildQuote':
+          return await buildQuote(i); // remoto padrão
+        case 'getAvailability':
+          return await getAvailability(i);
+        case 'createAppointment':
+          return await createAppointment(i);
+        case 'cancelAppointment':
+          return await cancelAppointment(i);
+        case 'getOrderStatus':
+          return await getOrderStatus(i?.id || i);
       }
     } else {
       switch (n) {
-        case 'buildQuote': return await buildQuoteMW(i); // remoto via middleware
-        case 'getAvailability': return await getAvailabilityMW(i);
-        case 'createAppointment': return await createAppointmentMW(i);
-        case 'cancelAppointment': return await cancelAppointmentMW(i);
-        case 'getOrderStatus': return await getOrderStatusMW(i?.id || i);
+        case 'buildQuote':
+          return await buildQuoteMW(i); // remoto via middleware
+        case 'getAvailability':
+          return await getAvailabilityMW(i);
+        case 'createAppointment':
+          return await createAppointmentMW(i);
+        case 'cancelAppointment':
+          return await cancelAppointmentMW(i);
+        case 'getOrderStatus':
+          return await getOrderStatusMW(i?.id || i);
       }
     }
     throw new Error('Tool not found');
@@ -27,9 +49,8 @@ export async function tryExecuteToolByName(name: string, input: any){
   return await fn(name, input);
 }
 
-
 // Experimental: usar catálogo local para prévia de orçamento quando input.localPreview === true
-export async function tryExecuteToolByNameWithLocalPreview(name: string, input: any){
+export async function tryExecuteToolByNameWithLocalPreview(name: string, input: any) {
   if (name !== 'buildQuote' || !input?.localPreview) return tryExecuteToolByName(name, input);
   const { buildLocalQuoteMessage } = await import('./quoteLocal.js');
   try {
@@ -39,4 +60,3 @@ export async function tryExecuteToolByNameWithLocalPreview(name: string, input: 
     return tryExecuteToolByName(name, input);
   }
 }
-

--- a/webhook-ai/src/services/tools.ts
+++ b/webhook-ai/src/services/tools.ts
@@ -3,60 +3,105 @@ import type { ChatMessage } from './llmClient.js';
 export const toolCatalog = {
   getAvailability: {
     description: 'Obter disponibilidade de agenda para data/serviço',
-    inputSchema: { type: 'object', properties: { date:{type:'string'}, service_type:{type:'string'}, region:{type:'string'}, duration:{type:'number'}, equipment:{type:'string'} }, required:['date'] }
+    inputSchema: {
+      type: 'object',
+      properties: {
+        date: { type: 'string' },
+        service_type: { type: 'string' },
+        region: { type: 'string' },
+        duration: { type: 'number' },
+        equipment: { type: 'string' },
+      },
+      required: ['date'],
+    },
   },
   createAppointment: {
     description: 'Criar agendamento',
-    inputSchema: { type: 'object', properties: {
-      client_name:{type:'string'}, start_time:{type:'string'}, end_time:{type:'string'},
-      address:{type:'string'}, address_complement:{type:'string'},
-      description:{type:'string'}, phone:{type:'string'}, region:{type:'string'}, equipment_type:{type:'string'},
-      email:{type:'string'}, cpf:{type:'string'}
-    }, required:['client_name','start_time','end_time'] }
+    inputSchema: {
+      type: 'object',
+      properties: {
+        client_name: { type: 'string' },
+        start_time: { type: 'string' },
+        end_time: { type: 'string' },
+        address: { type: 'string' },
+        address_complement: { type: 'string' },
+        description: { type: 'string' },
+        phone: { type: 'string' },
+        region: { type: 'string' },
+        equipment_type: { type: 'string' },
+        email: { type: 'string' },
+        cpf: { type: 'string' },
+      },
+      required: ['client_name', 'start_time', 'end_time'],
+    },
   },
   cancelAppointment: {
     description: 'Cancelar agendamento',
-    inputSchema: { type: 'object', properties: { id:{type:'string'}, reason:{type:'string'} }, required:['id'] }
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string' }, reason: { type: 'string' } },
+      required: ['id'],
+    },
   },
   buildQuote: {
     description: 'Estimar orçamento',
-    inputSchema: { type: 'object', properties: {
-      // chave principal (pode ser genérica; o runtime mapeia para mais específica)
-      service_type:{type:'string'},
-      region:{type:'string'}, urgency:{type:'string'},
-      // contexto para mapeamento inteligente de preço
-      equipment:{type:'string'}, // ex.: fogão, forno, micro-ondas, coifa
-      power_type:{type:'string'}, // gás | indução | elétrico
-      mount:{type:'string'}, // piso | cooktop | bancada | embutido
-      num_burners:{type:'string'}, // 4 | 5 | 6 ... (texto livre)
-      origin:{type:'string'}, // nacional | importado
-      is_industrial:{type:'boolean'},
-      brand:{type:'string'},
-      problem:{type:'string'},
-      segment:{type:'string'}, // basico | inox | premium
-      class_level:{type:'string'} // para inox: basico | premium
-    }, required:['service_type'] }
+    inputSchema: {
+      type: 'object',
+      properties: {
+        // chave principal (pode ser genérica; o runtime mapeia para mais específica)
+        service_type: { type: 'string' },
+        region: { type: 'string' },
+        urgency: { type: 'string' },
+        // contexto para mapeamento inteligente de preço
+        equipment: { type: 'string' }, // ex.: fogão, forno, micro-ondas, coifa
+        power_type: { type: 'string' }, // gás | indução | elétrico
+        mount: { type: 'string' }, // piso | cooktop | bancada | embutido
+        num_burners: { type: 'string' }, // 4 | 5 | 6 ... (texto livre)
+        origin: { type: 'string' }, // nacional | importado
+        is_industrial: { type: 'boolean' },
+        brand: { type: 'string' },
+        problem: { type: 'string' },
+        segment: { type: 'string' }, // basico | inox | premium
+        class_level: { type: 'string' }, // para inox: basico | premium
+      },
+      required: ['service_type'],
+    },
   },
   getOrderStatus: {
     description: 'Obter status da ordem de serviço por ID',
-    inputSchema: { type: 'object', properties: { id:{type:'string'} }, required:['id'] }
+    inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
   },
   aiScheduleStart: {
     description: 'Iniciar agendamento inteligente (ETAPA 1) usando middleware.py',
-    inputSchema: { type: 'object', properties: {
-      nome:{type:'string'}, endereco:{type:'string'}, equipamento:{type:'string'}, problema:{type:'string'}, telefone:{type:'string'}, urgente:{type:'boolean'}
-    }, required:['equipamento','problema'] }
+    inputSchema: {
+      type: 'object',
+      properties: {
+        nome: { type: 'string' },
+        endereco: { type: 'string' },
+        equipamento: { type: 'string' },
+        problema: { type: 'string' },
+        telefone: { type: 'string' },
+        urgente: { type: 'boolean' },
+      },
+      required: ['equipamento', 'problema'],
+    },
   },
   aiScheduleConfirm: {
     description: 'Confirmar agendamento inteligente (ETAPA 2) após cliente escolher 1/2/3',
-    inputSchema: { type: 'object', properties: { opcao_escolhida:{type:'string', enum:['1','2','3']}, telefone:{type:'string'} }, required:['opcao_escolhida'] }
-  }
+    inputSchema: {
+      type: 'object',
+      properties: {
+        opcao_escolhida: { type: 'string', enum: ['1', '2', '3'] },
+        telefone: { type: 'string' },
+      },
+      required: ['opcao_escolhida'],
+    },
+  },
 } as const;
 
 export type ToolName = keyof typeof toolCatalog;
 
-export function makeToolGuide(){
-  const lines = Object.entries(toolCatalog).map(([name,def])=>`- ${name}: ${def.description}`);
+export function makeToolGuide() {
+  const lines = Object.entries(toolCatalog).map(([name, def]) => `- ${name}: ${def.description}`);
   return `Ferramentas disponíveis:\n${lines.join('\n')}\n\nSe precisar usar uma ferramenta, responda SOMENTE com JSON no formato:\n{"tool":"<nome>","input":{...}}\nSe faltar dado, peça as informações antes de chamar a ferramenta.`;
 }
-

--- a/webhook-ai/src/services/toolsRuntime.ts
+++ b/webhook-ai/src/services/toolsRuntime.ts
@@ -2,38 +2,61 @@ import 'dotenv/config';
 
 const API_URL = process.env.API_URL || 'http://127.0.0.1:3001';
 const MIDDLEWARE_URL = process.env.MIDDLEWARE_URL || process.env.API_URL || 'http://127.0.0.1:8000';
-const QUOTE_OFFLINE_FALLBACK = (process.env.QUOTE_OFFLINE_FALLBACK === 'true') || (process.env.NODE_ENV === 'test');
+const QUOTE_OFFLINE_FALLBACK =
+  process.env.QUOTE_OFFLINE_FALLBACK === 'true' || process.env.NODE_ENV === 'test';
 
-function computeLocalQuote(payload: any){
+function computeLocalQuote(payload: any) {
   // Fallback determinístico simplificado para testes offline
-  const eq = String(payload?.equipment||'').toLowerCase();
-  const st = String(payload?.service_type||'domicilio');
+  const eq = String(payload?.equipment || '').toLowerCase();
+  const st = String(payload?.service_type || 'domicilio');
   let base = 120;
   if (eq.includes('fog')) base = 150;
   if (eq.includes('forno') && st.includes('coleta')) base = 180;
   if (eq.includes('micro')) base = 130;
   const value = base;
-  return { found: true, value, currency: 'BRL', service_type: st, equipment: payload?.equipment||'equipamento', brand: payload?.brand||null, problem: payload?.problem||null };
+  return {
+    found: true,
+    value,
+    currency: 'BRL',
+    service_type: st,
+    equipment: payload?.equipment || 'equipamento',
+    brand: payload?.brand || null,
+    problem: payload?.problem || null,
+  };
 }
 
-type BuildQuoteInput = { service_type: string; region?: string|null; urgency?: string|null; equipment?: string|null; power_type?: string|null; mount?: string|null; num_burners?: string|null; origin?: string|null; is_industrial?: boolean|null; brand?: string|null; problem?: string|null; segment?: string|null; class_level?: string|null };
+type BuildQuoteInput = {
+  service_type: string;
+  region?: string | null;
+  urgency?: string | null;
+  equipment?: string | null;
+  power_type?: string | null;
+  mount?: string | null;
+  num_burners?: string | null;
+  origin?: string | null;
+  is_industrial?: boolean | null;
+  brand?: string | null;
+  problem?: string | null;
+  segment?: string | null;
+  class_level?: string | null;
+};
 
-export async function buildQuote(input: BuildQuoteInput){
+export async function buildQuote(input: BuildQuoteInput) {
   // Mapeamento inteligente para service_type específico de price_list
   let st = input.service_type?.toLowerCase() || '';
-  const eq = (input.equipment||'').toLowerCase();
-  const power = (input.power_type||'').toLowerCase();
-  const mount = (input.mount||'').toLowerCase();
-  const burners = (input.num_burners||'').toLowerCase();
-  const origin = (input.origin||'').toLowerCase();
+  const eq = (input.equipment || '').toLowerCase();
+  const power = (input.power_type || '').toLowerCase();
+  const mount = (input.mount || '').toLowerCase();
+  const burners = (input.num_burners || '').toLowerCase();
+  const origin = (input.origin || '').toLowerCase();
   const industrial = !!input.is_industrial;
-  let seg = (input.segment||'').toLowerCase();
-  const classLevel = String((input as any).class_level||'').toLowerCase();
+  let seg = (input.segment || '').toLowerCase();
+  const classLevel = String((input as any).class_level || '').toLowerCase();
 
   // Consolidar segmento por regras de marca (chama API interna) — pular em modo de teste/offline
   if (!QUOTE_OFFLINE_FALLBACK) {
     try {
-      const brand = String(input.brand||'').trim();
+      const brand = String(input.brand || '').trim();
       if (brand) {
         const qs = new URLSearchParams({ brand, mount });
         const primary = API_URL;
@@ -41,55 +64,70 @@ export async function buildQuote(input: BuildQuoteInput){
         let resp: Response | null = null;
         try {
           resp = await fetch(`${primary}/api/brand-rules/resolve?${qs.toString()}`);
-        } catch (e:any) {
-          const msg = String(e?.message||'');
-          if ((msg.includes('ECONNREFUSED') || msg.includes('fetch failed') || msg.includes('Connect Timeout')) && !primary.includes('127.0.0.1') && !primary.includes('localhost')) {
-            try { resp = await fetch(`${fallback}/api/brand-rules/resolve?${qs.toString()}`); } catch {}
+        } catch (e: any) {
+          const msg = String(e?.message || '');
+          if (
+            (msg.includes('ECONNREFUSED') ||
+              msg.includes('fetch failed') ||
+              msg.includes('Connect Timeout')) &&
+            !primary.includes('127.0.0.1') &&
+            !primary.includes('localhost')
+          ) {
+            try {
+              resp = await fetch(`${fallback}/api/brand-rules/resolve?${qs.toString()}`);
+            } catch {}
           }
         }
-        if (resp && resp.ok){
+        if (resp && resp.ok) {
           const data = await resp.json();
           const rule = data?.rule;
-          if (rule){
-            const recommended = String(rule.recommended_segment||'').toLowerCase();
-            const strat = String(rule.strategy||'infer_by_photos');
+          if (rule) {
+            const recommended = String(rule.recommended_segment || '').toLowerCase();
+            const strat = String(rule.strategy || 'infer_by_photos');
             if (strat === 'force' && recommended) seg = recommended;
-            else if (strat === 'prefer' && recommended){
-              const rank = (s:string)=> s==='premium'?3 : s==='inox'?2 : s==='basico'?1 : 0;
+            else if (strat === 'prefer' && recommended) {
+              const rank = (s: string) =>
+                s === 'premium' ? 3 : s === 'inox' ? 2 : s === 'basico' ? 1 : 0;
               if (rank(recommended) > rank(seg)) seg = recommended;
             }
           }
         }
       }
-    } catch (e:any) {
-      console.warn('[buildQuote] brand rule consolidation failed', e?.message||e);
+    } catch (e: any) {
+      console.warn('[buildQuote] brand rule consolidation failed', e?.message || e);
     }
   }
 
   // Regras contextualizadas
   if (eq.includes('coifa')) st = 'domicilio_coifa';
 
-  if (eq.includes('fogão') || eq.includes('fogao') || eq.includes('cooktop')){
-    if (power.includes('gás') || power.includes('gas')){
+  if (eq.includes('fogão') || eq.includes('fogao') || eq.includes('cooktop')) {
+    if (power.includes('gás') || power.includes('gas')) {
       // domicílio com especializações
-      if (mount.includes('cooktop') || eq.includes('cooktop')){
+      if (mount.includes('cooktop') || eq.includes('cooktop')) {
         if (burners.includes('4')) {
-          if (seg==='premium') st = 'domicilio_fogao_cooktop4_premium';
-          else st = origin.includes('import') ? 'domicilio_fogao_cooktop4_importado' : 'domicilio_fogao_cooktop4_nacional';
+          if (seg === 'premium') st = 'domicilio_fogao_cooktop4_premium';
+          else
+            st = origin.includes('import')
+              ? 'domicilio_fogao_cooktop4_importado'
+              : 'domicilio_fogao_cooktop4_nacional';
         } else if (burners.includes('5')) {
-          if (seg==='premium') st = 'domicilio_fogao_cooktop5_premium';
-          else st = origin.includes('import') ? 'domicilio_fogao_cooktop5_importado' : 'domicilio_fogao_cooktop5_nacional';
+          if (seg === 'premium') st = 'domicilio_fogao_cooktop5_premium';
+          else
+            st = origin.includes('import')
+              ? 'domicilio_fogao_cooktop5_importado'
+              : 'domicilio_fogao_cooktop5_nacional';
         } else {
           st = 'domicilio';
         }
-      } else if (mount.includes('piso') || eq.includes('piso') || eq.includes('fogão')){
+      } else if (mount.includes('piso') || eq.includes('piso') || eq.includes('fogão')) {
         if (burners.includes('4')) {
-          if (seg==='inox') st = `domicilio_fogao_piso4_inox_${classLevel||'basico'}`;
-          else if (seg==='premium') st = 'domicilio_fogao_piso4_premium';
+          if (seg === 'inox') st = `domicilio_fogao_piso4_inox_${classLevel || 'basico'}`;
+          else if (seg === 'premium') st = 'domicilio_fogao_piso4_premium';
           else st = 'domicilio_fogao_piso4_nacional';
         } else if (burners.includes('5')) {
-          if (seg==='inox') st = `domicilio_fogao_piso5_inox_${classLevel||'basico'}`;
-          else if (seg==='premium') st = 'domicilio_fogao_piso5_premium';
+          if (seg === 'inox') st = `domicilio_fogao_piso5_inox_${classLevel || 'basico'}`;
+          else if (seg === 'premium') st = 'domicilio_fogao_piso5_premium';
           else st = 'domicilio_fogao_piso5_nacional';
         } else if (burners.includes('6')) {
           // Mantemos 6 bocas nacional (segmento pouco usado aqui)
@@ -104,31 +142,46 @@ export async function buildQuote(input: BuildQuoteInput){
   }
 
   // Fornos elétricos: nunca domicílio
-  if (eq.includes('forno') && (power.includes('elétrico') || power.includes('eletrico'))){
+  if (eq.includes('forno') && (power.includes('elétrico') || power.includes('eletrico'))) {
     if (mount.includes('bancada')) st = 'coleta_conserto';
     else st = 'coleta_diagnostico';
   }
 
   // Enviar também pistas de segmentação (basico/inox/premium)
   const payload: any = { ...input, service_type: st || input.service_type };
-  if (!payload.segment && (/(básico|basico|inox|premium)/i).test(`${input.segment||''} ${input.problem||''}`)) {
-    payload.segment = (input.segment||'').toLowerCase();
+  if (
+    !payload.segment &&
+    /(básico|basico|inox|premium)/i.test(`${input.segment || ''} ${input.problem || ''}`)
+  ) {
+    payload.segment = (input.segment || '').toLowerCase();
   }
-  if (payload.segment==='inox' && input['class_level']) {
+  if (payload.segment === 'inox' && input['class_level']) {
     payload.class_level = String(input['class_level']).toLowerCase();
   }
 
   const primary = API_URL;
   const fallback = 'http://127.0.0.1:3001';
   async function postQuote(base: string) {
-    return await fetch(`${base}/api/quote/estimate`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+    return await fetch(`${base}/api/quote/estimate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
   }
-  let resp = await postQuote(primary).catch(async (e)=>{
+  let resp = await postQuote(primary).catch(async (e) => {
     // Retry com fallback local em caso de ECONNREFUSED/fetch failed/timeout e host não-local
-    const msg = String(e?.message||'');
-    if ((msg.includes('ECONNREFUSED') || msg.includes('fetch failed') || msg.includes('Connect Timeout')) && !primary.includes('127.0.0.1') && !primary.includes('localhost')){
-      await new Promise(r=>setTimeout(r,300));
-      try { return await postQuote(fallback); } catch {}
+    const msg = String(e?.message || '');
+    if (
+      (msg.includes('ECONNREFUSED') ||
+        msg.includes('fetch failed') ||
+        msg.includes('Connect Timeout')) &&
+      !primary.includes('127.0.0.1') &&
+      !primary.includes('localhost')
+    ) {
+      await new Promise((r) => setTimeout(r, 300));
+      try {
+        return await postQuote(fallback);
+      } catch {}
     }
     // Em ambiente de teste, permitir fallback offline determinístico
     if (QUOTE_OFFLINE_FALLBACK) {
@@ -138,7 +191,9 @@ export async function buildQuote(input: BuildQuoteInput){
   });
   if (!resp || !resp.ok) {
     if (!resp && !primary.includes('127.0.0.1') && !primary.includes('localhost')) {
-      try { resp = await postQuote(fallback); } catch {}
+      try {
+        resp = await postQuote(fallback);
+      } catch {}
     }
     if ((!resp || !resp.ok) && QUOTE_OFFLINE_FALLBACK) {
       return computeLocalQuote(payload);
@@ -149,61 +204,94 @@ export async function buildQuote(input: BuildQuoteInput){
   return data?.result;
 }
 
-export async function getAvailability(params: { date: string; region?: string|null; service_type?: string|null; duration?: number }){
+export async function getAvailability(params: {
+  date: string;
+  region?: string | null;
+  service_type?: string | null;
+  duration?: number;
+}) {
   const qs = new URLSearchParams();
-  Object.entries(params).forEach(([k,v])=>{ if (v!==undefined && v!==null) qs.set(k, String(v)); });
+  Object.entries(params).forEach(([k, v]) => {
+    if (v !== undefined && v !== null) qs.set(k, String(v));
+  });
   const resp = await fetch(`${API_URL}/api/schedule/availability?${qs.toString()}`);
   if (!resp.ok) throw new Error(`availability failed: ${resp.status}`);
   return await resp.json();
 }
 
-export async function createAppointment(input: { client_name:string; start_time:string; end_time:string; address?:string }){
-  const resp = await fetch(`${API_URL}/api/schedule/book`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(input) });
+export async function createAppointment(input: {
+  client_name: string;
+  start_time: string;
+  end_time: string;
+  address?: string;
+}) {
+  const resp = await fetch(`${API_URL}/api/schedule/book`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
   if (!resp.ok) throw new Error(`book failed: ${resp.status}`);
   return await resp.json();
 }
 
-export async function cancelAppointment(input: { id:string; reason?:string }){
-  const resp = await fetch(`${API_URL}/api/schedule/cancel`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(input) });
+export async function cancelAppointment(input: { id: string; reason?: string }) {
+  const resp = await fetch(`${API_URL}/api/schedule/cancel`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
   if (!resp.ok) throw new Error(`cancel failed: ${resp.status}`);
   return await resp.json();
 }
 
-export async function getOrderStatus(id: string){
+export async function getOrderStatus(id: string) {
   const resp = await fetch(`${API_URL}/api/orders/${encodeURIComponent(id)}/status`);
   if (!resp.ok) throw new Error(`order_status failed: ${resp.status}`);
   return await resp.json();
 }
 
 // Integração com middleware.py (ETAPA 1 e 2) para seguir regras de logística, agenda e conversões
-export async function aiScheduleStart(input: { nome:string; endereco:string; equipamento:string; problema:string; telefone:string; urgente?:boolean }){
+export async function aiScheduleStart(input: {
+  nome: string;
+  endereco: string;
+  equipamento: string;
+  problema: string;
+  telefone: string;
+  urgente?: boolean;
+}) {
   // Test-mode: return deterministic stub to avoid external HTTP in CI/tests
   if (process.env.NODE_ENV === 'test') {
     return { message: 'Tenho estas opções de horário: 1) 09:00 2) 10:30 3) 14:00' };
   }
-  const resp = await fetch(`${MIDDLEWARE_URL}/agendamento-inteligente`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({
-    nome: input.nome,
-    endereco: input.endereco,
-    equipamento: input.equipamento,
-    problema: input.problema,
-    telefone: input.telefone,
-    urgente: input.urgente ? 'sim' : 'não'
-  })});
+  const resp = await fetch(`${MIDDLEWARE_URL}/agendamento-inteligente`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      nome: input.nome,
+      endereco: input.endereco,
+      equipamento: input.equipamento,
+      problema: input.problema,
+      telefone: input.telefone,
+      urgente: input.urgente ? 'sim' : 'não',
+    }),
+  });
   if (!resp.ok) throw new Error(`aiScheduleStart failed: ${resp.status}`);
   return await resp.json();
 }
 
-export async function aiScheduleConfirm(input: { telefone:string; opcao_escolhida:string }){
+export async function aiScheduleConfirm(input: { telefone: string; opcao_escolhida: string }) {
   // Test-mode: return deterministic confirmation
   if (process.env.NODE_ENV === 'test') {
     return { message: 'Agendamento confirmado!' };
   }
-  const resp = await fetch(`${MIDDLEWARE_URL}/agendamento-inteligente`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({
-    telefone: input.telefone,
-    opcao_escolhida: input.opcao_escolhida
-  })});
+  const resp = await fetch(`${MIDDLEWARE_URL}/agendamento-inteligente`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      telefone: input.telefone,
+      opcao_escolhida: input.opcao_escolhida,
+    }),
+  });
   if (!resp.ok) throw new Error(`aiScheduleConfirm failed: ${resp.status}`);
   return await resp.json();
 }
-
-

--- a/webhook-ai/src/services/toolsRuntimeMiddleware.ts
+++ b/webhook-ai/src/services/toolsRuntimeMiddleware.ts
@@ -3,34 +3,47 @@ import 'dotenv/config';
 const API_URL = process.env.API_URL || 'http://localhost:3000';
 const BOT_TOKEN = process.env.BOT_TOKEN || '';
 
-async function post(path: string, body: any){
+async function post(path: string, body: any) {
   const resp = await fetch(`${API_URL}${path}`, {
     method: 'POST',
-    headers: { 'Content-Type':'application/json', 'x-bot-token': BOT_TOKEN },
-    body: JSON.stringify(body || {})
+    headers: { 'Content-Type': 'application/json', 'x-bot-token': BOT_TOKEN },
+    body: JSON.stringify(body || {}),
   });
   if (!resp.ok) throw new Error(`Middleware call failed: ${resp.status} ${path}`);
   return await resp.json();
 }
 
-export async function buildQuoteMW(input: { service_type: string; region?: string|null; urgency?: string|null }){
+export async function buildQuoteMW(input: {
+  service_type: string;
+  region?: string | null;
+  urgency?: string | null;
+}) {
   const { result } = await post('/api/bot/tools/buildQuote', input);
   return result;
 }
 
-export async function getAvailabilityMW(params: { date: string; region?: string|null; service_type?: string|null; duration?: number }){
+export async function getAvailabilityMW(params: {
+  date: string;
+  region?: string | null;
+  service_type?: string | null;
+  duration?: number;
+}) {
   return await post('/api/bot/tools/getAvailability', params);
 }
 
-export async function createAppointmentMW(input: { client_name:string; start_time:string; end_time:string; address?:string }){
+export async function createAppointmentMW(input: {
+  client_name: string;
+  start_time: string;
+  end_time: string;
+  address?: string;
+}) {
   return await post('/api/bot/tools/createAppointment', input);
 }
 
-export async function cancelAppointmentMW(input: { id:string; reason?:string }){
+export async function cancelAppointmentMW(input: { id: string; reason?: string }) {
   return await post('/api/bot/tools/cancelAppointment', input);
 }
 
-export async function getOrderStatusMW(id: string){
+export async function getOrderStatusMW(id: string) {
   return await post('/api/bot/tools/getOrderStatus', { id });
 }
-

--- a/webhook-ai/src/services/waClient.ts
+++ b/webhook-ai/src/services/waClient.ts
@@ -16,8 +16,16 @@ class WhatsAppClient extends EventEmitter {
   private client: any;
   private status: WAStatus = { connected: false, me: null, qr: null };
   private started = false;
-  private messageHandlers: Array<(from: string, body: string, meta?: { id?: string; ts?: number; type?: string }) => Promise<void> | void> = [];
-  private anyMessageHandlers: Array<(msg: any, meta?: { id?: string; ts?: number; type?: string }) => Promise<void> | void> = [];
+  private messageHandlers: Array<
+    (
+      from: string,
+      body: string,
+      meta?: { id?: string; ts?: number; type?: string }
+    ) => Promise<void> | void
+  > = [];
+  private anyMessageHandlers: Array<
+    (msg: any, meta?: { id?: string; ts?: number; type?: string }) => Promise<void> | void
+  > = [];
 
   constructor() {
     super();
@@ -35,10 +43,15 @@ class WhatsAppClient extends EventEmitter {
         `${process.env.LOCALAPPDATA}/Google/Chrome/Application/chrome.exe`,
         // Microsoft Edge
         'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-        'C:/Program Files/Microsoft/Edge/Application/msedge.exe'
+        'C:/Program Files/Microsoft/Edge/Application/msedge.exe',
       ].filter(Boolean) as string[];
       for (const p of candidates) {
-        try { if (fs.existsSync(p)) { execPath = p; break; } } catch {}
+        try {
+          if (fs.existsSync(p)) {
+            execPath = p;
+            break;
+          }
+        } catch {}
       }
     }
     // Forçar modo visível por enquanto para estabilizar a autenticação
@@ -59,17 +72,28 @@ class WhatsAppClient extends EventEmitter {
     const defaultData = path.join(os.homedir(), '.wwebjs_auth', 'fixbot-v2');
     const chromeUserData = path.join(os.homedir(), '.wwebjs_chrome');
     const dataPath = process.env.WA_DATA_PATH || defaultData;
-    try { fs.mkdirSync(dataPath, { recursive: true }); } catch {}
-    try { fs.mkdirSync(chromeUserData, { recursive: true }); } catch {}
+    try {
+      fs.mkdirSync(dataPath, { recursive: true });
+    } catch {}
+    try {
+      fs.mkdirSync(chromeUserData, { recursive: true });
+    } catch {}
 
     this.client = new Client({
       authStrategy: new LocalAuth({ clientId: 'fixbot-v2', dataPath }),
-      puppeteer: { headless, args, executablePath: execPath, ignoreHTTPSErrors: true, devtools: false },
+      puppeteer: {
+        headless,
+        args,
+        executablePath: execPath,
+        ignoreHTTPSErrors: true,
+        devtools: false,
+      },
       // Pin de versão conhecido e cache remoto — evita loop em "Conectando" após scan
       webVersion: '2.3000.1026598401',
       webVersionCache: {
         type: 'remote',
-        remotePath: 'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.3000.1026598401.html'
+        remotePath:
+          'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.3000.1026598401.html',
       },
       takeoverOnConflict: true,
       takeoverTimeoutMs: 0,
@@ -102,7 +126,7 @@ class WhatsAppClient extends EventEmitter {
         body: msg.body?.slice(0, 100),
         type: msg.type,
         fromMe: msg.fromMe,
-        timestamp: msg.timestamp
+        timestamp: msg.timestamp,
       });
     });
 
@@ -113,7 +137,7 @@ class WhatsAppClient extends EventEmitter {
         body: msg.body?.slice(0, 100),
         type: msg.type,
         fromMe: msg.fromMe,
-        timestamp: msg.timestamp
+        timestamp: msg.timestamp,
       });
     });
 
@@ -180,10 +204,16 @@ class WhatsAppClient extends EventEmitter {
                   // Método 1: Store.Conn
                   // @ts-ignore
                   // @ts-ignore
-                  if ((window as any).Store && (window as any).Store.Conn && (window as any).Store.Conn.wid) {
+                  if (
+                    (window as any).Store &&
+                    (window as any).Store.Conn &&
+                    (window as any).Store.Conn.wid
+                  ) {
                     return {
-                      id: (window as any).Store.Conn.wid._serialized || (window as any).Store.Conn.wid.user,
-                      pushname: (window as any).Store.Conn.pushname
+                      id:
+                        (window as any).Store.Conn.wid._serialized ||
+                        (window as any).Store.Conn.wid.user,
+                      pushname: (window as any).Store.Conn.pushname,
                     };
                   }
 
@@ -193,14 +223,15 @@ class WhatsAppClient extends EventEmitter {
                   if (WAWebMain && WAWebMain.Conn && WAWebMain.Conn.wid) {
                     return {
                       id: WAWebMain.Conn.wid._serialized || WAWebMain.Conn.wid.user,
-                      pushname: WAWebMain.Conn.pushname
+                      pushname: WAWebMain.Conn.pushname,
                     };
                   }
 
                   // Método 3: Procurar no DOM
-                  const headerElement = document.querySelector('[data-testid="default-user"]') ||
-                                      document.querySelector('[title*="+"]') ||
-                                      document.querySelector('header [title]');
+                  const headerElement =
+                    document.querySelector('[data-testid="default-user"]') ||
+                    document.querySelector('[title*="+"]') ||
+                    document.querySelector('header [title]');
                   const he = headerElement as HTMLElement | null;
                   if (he && (he as any).title) {
                     const title = (he as any).title as string;
@@ -208,13 +239,15 @@ class WhatsAppClient extends EventEmitter {
                     if (phoneMatch) {
                       return {
                         id: phoneMatch[1] + '@c.us',
-                        pushname: title.replace(/\+?\d{10,15}/, '').trim()
+                        pushname: title.replace(/\+?\d{10,15}/, '').trim(),
                       };
                     }
                   }
 
                   // Método 4: Procurar elementos com números de telefone
-                  const phoneElements = document.querySelectorAll('[title*="+"], [aria-label*="+"]');
+                  const phoneElements = document.querySelectorAll(
+                    '[title*="+"], [aria-label*="+"]'
+                  );
                   for (const el of Array.from(phoneElements)) {
                     const he2 = el as HTMLElement;
                     const text = (he2 as any).title || he2.getAttribute('aria-label') || '';
@@ -222,7 +255,7 @@ class WhatsAppClient extends EventEmitter {
                     if (phoneMatch) {
                       return {
                         id: phoneMatch[1] + '@c.us',
-                        pushname: text.replace(/\+?\d{10,15}/, '').trim() || 'Bot'
+                        pushname: text.replace(/\+?\d{10,15}/, '').trim() || 'Bot',
                       };
                     }
                   }
@@ -239,7 +272,10 @@ class WhatsAppClient extends EventEmitter {
               }
             }
           } catch (e: any) {
-            console.log('[WA] Não foi possível executar JavaScript na página:', e?.message || String(e));
+            console.log(
+              '[WA] Não foi possível executar JavaScript na página:',
+              e?.message || String(e)
+            );
           }
         }
 
@@ -299,7 +335,10 @@ class WhatsAppClient extends EventEmitter {
                   pushname = me.pushname || me.name;
                 }
               } catch (e: any) {
-                console.log('[WA] WORKAROUND: Não foi possível obter contatos:', e?.message || String(e));
+                console.log(
+                  '[WA] WORKAROUND: Não foi possível obter contatos:',
+                  e?.message || String(e)
+                );
               }
             }
 
@@ -315,10 +354,16 @@ class WhatsAppClient extends EventEmitter {
                       // Método 1: Store.Conn
                       // @ts-ignore
                       // @ts-ignore
-                      if ((window as any).Store && (window as any).Store.Conn && (window as any).Store.Conn.wid) {
+                      if (
+                        (window as any).Store &&
+                        (window as any).Store.Conn &&
+                        (window as any).Store.Conn.wid
+                      ) {
                         return {
-                          id: (window as any).Store.Conn.wid._serialized || (window as any).Store.Conn.wid.user,
-                          pushname: (window as any).Store.Conn.pushname
+                          id:
+                            (window as any).Store.Conn.wid._serialized ||
+                            (window as any).Store.Conn.wid.user,
+                          pushname: (window as any).Store.Conn.pushname,
                         };
                       }
 
@@ -328,14 +373,15 @@ class WhatsAppClient extends EventEmitter {
                       if (WAWebMain && WAWebMain.Conn && WAWebMain.Conn.wid) {
                         return {
                           id: WAWebMain.Conn.wid._serialized || WAWebMain.Conn.wid.user,
-                          pushname: WAWebMain.Conn.pushname
+                          pushname: WAWebMain.Conn.pushname,
                         };
                       }
 
                       // Método 3: Procurar no DOM
-                      const headerElement = document.querySelector('[data-testid="default-user"]') ||
-                                          document.querySelector('[title*="+"]') ||
-                                          document.querySelector('header [title]');
+                      const headerElement =
+                        document.querySelector('[data-testid="default-user"]') ||
+                        document.querySelector('[title*="+"]') ||
+                        document.querySelector('header [title]');
                       const he = headerElement as HTMLElement | null;
                       if (he && (he as any).title) {
                         const title = (he as any).title as string;
@@ -343,13 +389,15 @@ class WhatsAppClient extends EventEmitter {
                         if (phoneMatch) {
                           return {
                             id: phoneMatch[1] + '@c.us',
-                            pushname: title.replace(/\+?\d{10,15}/, '').trim()
+                            pushname: title.replace(/\+?\d{10,15}/, '').trim(),
                           };
                         }
                       }
 
                       // Método 4: Procurar elementos com números de telefone
-                      const phoneElements = document.querySelectorAll('[title*="+"], [aria-label*="+"]');
+                      const phoneElements = document.querySelectorAll(
+                        '[title*="+"], [aria-label*="+"]'
+                      );
                       for (const el of Array.from(phoneElements)) {
                         const he2 = el as HTMLElement;
                         const text = (he2 as any).title || he2.getAttribute('aria-label') || '';
@@ -357,7 +405,7 @@ class WhatsAppClient extends EventEmitter {
                         if (phoneMatch) {
                           return {
                             id: phoneMatch[1] + '@c.us',
-                            pushname: text.replace(/\+?\d{10,15}/, '').trim() || 'Bot'
+                            pushname: text.replace(/\+?\d{10,15}/, '').trim() || 'Bot',
                           };
                         }
                       }
@@ -374,7 +422,10 @@ class WhatsAppClient extends EventEmitter {
                   }
                 }
               } catch (e: any) {
-                console.log('[WA] WORKAROUND: Não foi possível executar JavaScript:', e?.message || String(e));
+                console.log(
+                  '[WA] WORKAROUND: Não foi possível executar JavaScript:',
+                  e?.message || String(e)
+                );
               }
             }
 
@@ -422,7 +473,7 @@ class WhatsAppClient extends EventEmitter {
       }
       // auto-retry leve para manter QR disponível em dev
       try {
-        await new Promise(res => setTimeout(res, 2000));
+        await new Promise((res) => setTimeout(res, 2000));
         if (this.started) {
           console.log('[WA] Tentando reconectar...');
           this.initClient();
@@ -457,7 +508,9 @@ class WhatsAppClient extends EventEmitter {
       return;
     }
     // Força reinicialização (ex.: recuperação de erro)
-    try { await this.client.destroy(); } catch {}
+    try {
+      await this.client.destroy();
+    } catch {}
     this.started = false;
     this.status = { connected: false, me: null, qr: null };
     this.initClient();
@@ -469,16 +522,25 @@ class WhatsAppClient extends EventEmitter {
   }
 
   // Handler simplificado (texto)
-  public onMessage(handler: (from: string, body: string, meta?: { id?: string; ts?: number; type?: string }) => Promise<void> | void) {
+  public onMessage(
+    handler: (
+      from: string,
+      body: string,
+      meta?: { id?: string; ts?: number; type?: string }
+    ) => Promise<void> | void
+  ) {
     this.messageHandlers.push(handler);
-    console.log('[WA] 🔧 Registrando handler de mensagem. Total handlers:', this.messageHandlers.length);
+    console.log(
+      '[WA] 🔧 Registrando handler de mensagem. Total handlers:',
+      this.messageHandlers.length
+    );
 
     // Garante apenas um listener real no client
     if (!(this as any)._boundMessageListener) {
       console.log('[WA] 🔧 Criando listener de mensagem no client');
       (this as any)._boundMessageListener = async (msg: any) => {
         try {
-          const preview = msg?.body ? String(msg.body).slice(0, 80) : `[${msg.type||'unknown'}]`;
+          const preview = msg?.body ? String(msg.body).slice(0, 80) : `[${msg.type || 'unknown'}]`;
           console.log('[WA] 📨 MENSAGEM RECEBIDA de', msg.from, 'texto:', preview);
           console.log('[WA] 📨 Detalhes da mensagem:', {
             from: msg.from,
@@ -487,10 +549,14 @@ class WhatsAppClient extends EventEmitter {
             type: msg.type,
             fromMe: msg.fromMe,
             timestamp: msg.timestamp,
-            id: msg?.id?._serialized || msg?.id?.id
+            id: msg?.id?._serialized || msg?.id?.id,
           });
 
-          const meta = { id: msg?.id?._serialized || msg?.id?.id, ts: msg?.timestamp, type: msg?.type };
+          const meta = {
+            id: msg?.id?._serialized || msg?.id?.id,
+            ts: msg?.timestamp,
+            type: msg?.type,
+          };
           console.log('[WA] 📨 Processando com', this.messageHandlers.length, 'handlers');
 
           for (const h of this.messageHandlers) {
@@ -513,14 +579,24 @@ class WhatsAppClient extends EventEmitter {
   }
 
   // Handler raw para acessar mídias/imagens
-  public onAnyMessage(handler: (msg: any, meta?: { id?: string; ts?: number; type?: string }) => Promise<void> | void) {
+  public onAnyMessage(
+    handler: (msg: any, meta?: { id?: string; ts?: number; type?: string }) => Promise<void> | void
+  ) {
     this.anyMessageHandlers.push(handler);
     if (!(this as any)._boundAnyMessageListener) {
       (this as any)._boundAnyMessageListener = async (msg: any) => {
         try {
-          const meta = { id: msg?.id?._serialized || msg?.id?.id, ts: msg?.timestamp, type: msg?.type };
+          const meta = {
+            id: msg?.id?._serialized || msg?.id?.id,
+            ts: msg?.timestamp,
+            type: msg?.type,
+          };
           for (const h of this.anyMessageHandlers) {
-            try { await h(msg, meta); } catch (e) { console.error('[WA] onAnyMessage handler error', e); }
+            try {
+              await h(msg, meta);
+            } catch (e) {
+              console.error('[WA] onAnyMessage handler error', e);
+            }
           }
         } catch (e) {
           console.error('[WA] onAnyMessage dispatch error', e);
@@ -530,13 +606,13 @@ class WhatsAppClient extends EventEmitter {
     }
   }
 
-  public async sendButtons(to: string, text: string, buttons: Array<{id: string, text: string}>) {
+  public async sendButtons(to: string, text: string, buttons: Array<{ id: string; text: string }>) {
     // whatsapp-web.js mudou a API - usando fallback direto para texto simples
     try {
       // Tentativa com nova API se disponível
       const { Buttons } = await import('whatsapp-web.js');
       if (Buttons && typeof Buttons === 'function') {
-        const btns = buttons.map(b => ({ id: b.id, body: b.text }));
+        const btns = buttons.map((b) => ({ id: b.id, body: b.text }));
         const msg = new Buttons(text, btns);
         return (this.client as any).sendMessage(to, msg);
       }
@@ -545,20 +621,26 @@ class WhatsAppClient extends EventEmitter {
     }
 
     // Fallback: texto simples com numeração
-    const fallback = text + '\n\n' + buttons.map((b,i)=> `${i+1}) ${b.text}`).join('\n');
+    const fallback = text + '\n\n' + buttons.map((b, i) => `${i + 1}) ${b.text}`).join('\n');
     return (this.client as any).sendMessage(to, fallback);
   }
 
-  public async sendList(to: string, text: string, options: Array<{id: string, text: string}>, title='Opções', sectionTitle='Escolha:') {
+  public async sendList(
+    to: string,
+    text: string,
+    options: Array<{ id: string; text: string }>,
+    title = 'Opções',
+    sectionTitle = 'Escolha:'
+  ) {
     try {
       const List = (await import('whatsapp-web.js')).List as any;
-      const rows = options.map(o => ({ id: o.id, title: o.text }));
+      const rows = options.map((o) => ({ id: o.id, title: o.text }));
       const sections = [{ title: sectionTitle, rows }];
       const list = new List(text, 'Selecionar', sections, title);
       return (this.client as any).sendMessage(to, list);
     } catch (e) {
       console.warn('[WA] sendList falhou, fallback para texto simples', e);
-      const fallback = text + '\n' + options.map((o,i)=> `${i+1}) ${o.text}`).join('\n');
+      const fallback = text + '\n' + options.map((o, i) => `${i + 1}) ${o.text}`).join('\n');
       return (this.client as any).sendMessage(to, fallback);
     }
   }
@@ -568,7 +650,9 @@ class WhatsAppClient extends EventEmitter {
   }
 
   public async reset() {
-    try { await this.client.destroy(); } catch {}
+    try {
+      await this.client.destroy();
+    } catch {}
     this.status = { connected: false, me: null, qr: null };
     this.started = false;
     this.initClient();
@@ -593,7 +677,7 @@ class WhatsAppClient extends EventEmitter {
           const path = await import('path');
           const authDir = path.join(process.cwd(), '.wwebjs_auth');
           if (fs.existsSync(authDir)) {
-            await new Promise(resolve => setTimeout(resolve, 2000)); // aguarda 2s
+            await new Promise((resolve) => setTimeout(resolve, 2000)); // aguarda 2s
             fs.rmSync(authDir, { recursive: true, force: true });
             console.log('[WA] Sessão limpa manualmente');
           }
@@ -632,22 +716,27 @@ class WhatsAppClient extends EventEmitter {
             const chats = Store.Chat.models || [];
             const recentMessages = [];
             const now = Date.now();
-            const fiveMinutesAgo = now - (5 * 60 * 1000);
+            const fiveMinutesAgo = now - 5 * 60 * 1000;
 
-            for (const chat of chats.slice(0, 10)) { // Verificar apenas os 10 chats mais recentes
+            for (const chat of chats.slice(0, 10)) {
+              // Verificar apenas os 10 chats mais recentes
               if (!chat.msgs || !chat.msgs.models) continue;
 
-              for (const msg of chat.msgs.models.slice(-5)) { // Últimas 5 mensagens de cada chat
+              for (const msg of chat.msgs.models.slice(-5)) {
+                // Últimas 5 mensagens de cada chat
                 if (!msg || msg.fromMe) continue; // Ignorar mensagens próprias
 
                 const timestamp = msg.t * 1000; // Converter para milliseconds
-                if (timestamp > fiveMinutesAgo && timestamp > ((window as any).lastPollingCheck || 0)) {
+                if (
+                  timestamp > fiveMinutesAgo &&
+                  timestamp > ((window as any).lastPollingCheck || 0)
+                ) {
                   recentMessages.push({
                     id: msg.id._serialized || msg.id.id,
                     from: msg.from._serialized || msg.from,
                     body: msg.body || '',
                     timestamp: timestamp,
-                    type: msg.type || 'chat'
+                    type: msg.type || 'chat',
                   });
                 }
               }
@@ -667,7 +756,7 @@ class WhatsAppClient extends EventEmitter {
             console.log('[WA] 🔄 POLLING: Mensagem encontrada!', {
               from: msg.from,
               body: msg.body?.slice(0, 50),
-              timestamp: new Date(msg.timestamp).toISOString()
+              timestamp: new Date(msg.timestamp).toISOString(),
             });
 
             // Disparar handlers manualmente
@@ -683,7 +772,6 @@ class WhatsAppClient extends EventEmitter {
         }
 
         this.lastMessageCheck = Date.now();
-
       } catch (error) {
         console.error('[WA] Erro no polling:', error);
       }
@@ -700,4 +788,3 @@ class WhatsAppClient extends EventEmitter {
 }
 
 export const waClient = new WhatsAppClient();
-

--- a/webhook-ai/src/services/whatsapp.ts
+++ b/webhook-ai/src/services/whatsapp.ts
@@ -42,4 +42,3 @@ export function normalizePhone(p?: string | null): string | null {
   if (!p) return null;
   return p.replace(/\D/g, '');
 }
-

--- a/webhook-ai/test/ambiguity.spec.ts
+++ b/webhook-ai/test/ambiguity.spec.ts
@@ -11,14 +11,28 @@ describe('Ambiguidade: forno vs fogão a gás vs forno elétrico', () => {
   });
 
   it('mapeia "forno do fogão" para fogão a gás (domicílio)', async () => {
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'orcamento_equipamento', acao_principal:'gerar_orcamento', dados_extrair:{ equipamento: 'fogão a gás' } });
-    const out = await orchestrateInbound('whatsapp:+550000', 'o forno do fogão não esquenta', { id: 's1', channel: 'whatsapp', peer: '+550000', state: {} } as any);
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'orcamento_equipamento',
+      acao_principal: 'gerar_orcamento',
+      dados_extrair: { equipamento: 'fogão a gás' },
+    });
+    const out = await orchestrateInbound('whatsapp:+550000', 'o forno do fogão não esquenta', {
+      id: 's1',
+      channel: 'whatsapp',
+      peer: '+550000',
+      state: {},
+    } as any);
     const text = typeof out === 'string' ? out : (out as any).text || '';
     expect(text.toLowerCase()).toContain('fogão a gás');
   });
 
   it('pergunta e oferece opções quando somente "forno"', async () => {
-    const out = await orchestrateInbound('whatsapp:+550000', 'meu forno', { id: 's2', channel: 'whatsapp', peer: '+550000', state: {} } as any);
+    const out = await orchestrateInbound('whatsapp:+550000', 'meu forno', {
+      id: 's2',
+      channel: 'whatsapp',
+      peer: '+550000',
+      state: {},
+    } as any);
     if (typeof out !== 'string') {
       expect(out.text).toBeTruthy();
       expect(Array.isArray(out.options)).toBe(true);
@@ -28,10 +42,18 @@ describe('Ambiguidade: forno vs fogão a gás vs forno elétrico', () => {
 
 describe('Anti-loop de agendamento', () => {
   it('aceita agendamento com equipamento coletado, mesmo sem problema', async () => {
-    const session = { id: 's3', channel: 'whatsapp', peer: '+550000', state: { dados_coletados: { equipamento: 'fogão a gás' }, orcamento_entregue: true } } as any;
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'agendamento_servico', acao_principal:'agendar_servico', dados_extrair:{ equipamento: 'fogão a gás' } });
+    const session = {
+      id: 's3',
+      channel: 'whatsapp',
+      peer: '+550000',
+      state: { dados_coletados: { equipamento: 'fogão a gás' }, orcamento_entregue: true },
+    } as any;
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'agendamento_servico',
+      acao_principal: 'agendar_servico',
+      dados_extrair: { equipamento: 'fogão a gás' },
+    });
     const out = await orchestrateInbound('whatsapp:+550000', 'sim, pode agendar', session);
     expect(out).toBeTruthy();
   });
 });
-

--- a/webhook-ai/test/orchestrator-flow.spec.ts
+++ b/webhook-ai/test/orchestrator-flow.spec.ts
@@ -17,22 +17,44 @@ describe('Orchestrator: cenários avançados de fluxo', () => {
   });
 
   it('não agenda sem orçamento entregue, mesmo com equipamento no contexto', async () => {
-    await setSessionState(session.id, { ...(session.state||{}), dados_coletados: { equipamento: 'fogão a gás', problema: 'não acende' }, orcamento_entregue: false });
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'agendamento_servico', acao_principal:'agendar_servico', dados_extrair:{ equipamento: 'fogão a gás' }, resposta_sugerida: 'Vamos agendar' });
+    await setSessionState(session.id, {
+      ...(session.state || {}),
+      dados_coletados: { equipamento: 'fogão a gás', problema: 'não acende' },
+      orcamento_entregue: false,
+    });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'agendamento_servico',
+      acao_principal: 'agendar_servico',
+      dados_extrair: { equipamento: 'fogão a gás' },
+      resposta_sugerida: 'Vamos agendar',
+    });
     const out = await orchestrateInbound(FROM, 'quero agendar', session);
     const text = typeof out === 'string' ? out : (out as any)?.text || '';
-    expect((text||'').toLowerCase()).toMatch(/orçamento|orcamento/);
+    expect((text || '').toLowerCase()).toMatch(/orçamento|orcamento/);
   });
 
   it('aceitar orçamento ativa agendamento (intenção explícita)', async () => {
-    await setSessionState(session.id, { ...(session.state||{}), dados_coletados: { equipamento: 'fogão a gás', problema: 'não acende' }, orcamento_entregue: true });
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'agendamento_servico', acao_principal:'agendar_servico', dados_extrair:{ equipamento: 'fogão a gás' }, resposta_sugerida: 'Vamos agendar' });
+    await setSessionState(session.id, {
+      ...(session.state || {}),
+      dados_coletados: { equipamento: 'fogão a gás', problema: 'não acende' },
+      orcamento_entregue: true,
+    });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'agendamento_servico',
+      acao_principal: 'agendar_servico',
+      dados_extrair: { equipamento: 'fogão a gás' },
+      resposta_sugerida: 'Vamos agendar',
+    });
     const out = await orchestrateInbound(FROM, 'aceito o orçamento, pode agendar', session);
     expect(typeof out).toBe('string');
   });
 
   it('troca de equipamento reseta orcamento_entregue e evita agendamento automático', async () => {
-    await setSessionState(session.id, { ...(session.state||{}), dados_coletados: { equipamento: 'fogão a gás' }, orcamento_entregue: true });
+    await setSessionState(session.id, {
+      ...(session.state || {}),
+      dados_coletados: { equipamento: 'fogão a gás' },
+      orcamento_entregue: true,
+    });
     // usuário muda para fogão elétrico
     const out1 = await orchestrateInbound(FROM, 'na verdade é fogão elétrico', session);
     expect(out1).toBeTruthy();
@@ -43,27 +65,44 @@ describe('Orchestrator: cenários avançados de fluxo', () => {
     expect(!!st.orcamento_entregue).toBe(false);
 
     // Mesmo pedindo agendamento, não deve agendar sem novo orçamento
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'agendamento_servico', acao_principal:'agendar_servico', dados_extrair:{ equipamento: 'fogão elétrico' }, resposta_sugerida: 'Vamos agendar' });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'agendamento_servico',
+      acao_principal: 'agendar_servico',
+      dados_extrair: { equipamento: 'fogão elétrico' },
+      resposta_sugerida: 'Vamos agendar',
+    });
     const out2 = await orchestrateInbound(FROM, 'pode agendar', session);
     const text2 = typeof out2 === 'string' ? out2 : (out2 as any)?.text || '';
-    expect((text2||'').toLowerCase()).toMatch(/orçamento|orcamento/);
+    expect((text2 || '').toLowerCase()).toMatch(/orçamento|orcamento/);
   });
 
   it('abreviações mapeiam corretamente: eletr, gas, indu', async () => {
     const s1 = await getOrCreateSession('wa', 'test:+5511977777777');
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'orcamento_equipamento', acao_principal:'gerar_orcamento', dados_extrair:{ equipamento: 'forno elétrico' } });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'orcamento_equipamento',
+      acao_principal: 'gerar_orcamento',
+      dados_extrair: { equipamento: 'forno elétrico' },
+    });
     const o1 = await orchestrateInbound('test:+5511977777777', 'forno eletr', s1);
     const t1 = typeof o1 === 'string' ? o1 : (o1 as any).text || '';
     expect(t1.toLowerCase()).toMatch(/elétric|eletric/);
 
     const s2 = await getOrCreateSession('wa', 'test:+5511966666666');
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'orcamento_equipamento', acao_principal:'gerar_orcamento', dados_extrair:{ equipamento: 'fogão a gás' } });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'orcamento_equipamento',
+      acao_principal: 'gerar_orcamento',
+      dados_extrair: { equipamento: 'fogão a gás' },
+    });
     const o2 = await orchestrateInbound('test:+5511966666666', 'fogão gas', s2);
     const t2 = typeof o2 === 'string' ? o2 : (o2 as any).text || '';
     expect(t2.toLowerCase()).toMatch(/gás|gas/);
 
     const s3 = await getOrCreateSession('wa', 'test:+5511955555555');
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'orcamento_equipamento', acao_principal:'gerar_orcamento', dados_extrair:{ equipamento: 'fogão de indução' } });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'orcamento_equipamento',
+      acao_principal: 'gerar_orcamento',
+      dados_extrair: { equipamento: 'fogão de indução' },
+    });
     const o3 = await orchestrateInbound('test:+5511955555555', 'fogão indu', s3);
     const t3 = typeof o3 === 'string' ? o3 : (o3 as any).text || '';
     expect(t3.toLowerCase()).toMatch(/indu/);
@@ -71,12 +110,20 @@ describe('Orchestrator: cenários avançados de fluxo', () => {
 
   it('proteção anti-loop persiste ao longo de múltiplas mensagens', async () => {
     const s = await getOrCreateSession('wa', 'test:+5511944444444');
-    await setSessionState(s.id, { ...(s.state||{}), dados_coletados: { equipamento: 'fogão a gás' }, orcamento_entregue: true });
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'agendamento_servico', acao_principal:'agendar_servico', dados_extrair:{ equipamento: 'fogão a gás' }, resposta_sugerida:'Vamos agendar' });
+    await setSessionState(s.id, {
+      ...(s.state || {}),
+      dados_coletados: { equipamento: 'fogão a gás' },
+      orcamento_entregue: true,
+    });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'agendamento_servico',
+      acao_principal: 'agendar_servico',
+      dados_extrair: { equipamento: 'fogão a gás' },
+      resposta_sugerida: 'Vamos agendar',
+    });
     const r1 = await orchestrateInbound('test:+5511944444444', 'quero agendar', s);
     const r2 = await orchestrateInbound('test:+5511944444444', 'quero agendar', s);
     expect(r1).toBeTruthy();
     expect(r2).toBeTruthy();
   });
 });
-

--- a/webhook-ai/test/pending-switch.spec.ts
+++ b/webhook-ai/test/pending-switch.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { orchestrateInbound } from '../src/services/conversationOrchestrator.js';
+import { getOrCreateSession, setSessionState } from '../src/services/sessionStore.js';
+
+const FROM = 'test:+5511990000000';
+
+describe('Confirmação de troca de equipamento (pendingEquipmentSwitch)', () => {
+  let session: any;
+
+  beforeAll(async () => {
+    session = await getOrCreateSession('wa', FROM);
+  });
+
+  it('quando pending existe e usuário confirma (sim), troca equipamento e reseta orçamento', async () => {
+    await setSessionState(session.id, { ...(session.state||{}),
+      dados_coletados: { equipamento: 'fogão a gás', marca: 'Brastemp', problema: 'não acende' },
+      orcamento_entregue: true,
+      pendingEquipmentSwitch: 'fogão elétrico'
+    });
+
+    const out = await orchestrateInbound(FROM, 'sim, pode trocar', session);
+    const text = typeof out === 'string' ? out : (out as any)?.text || '';
+    expect(text.toLowerCase()).toContain('fogão elétrico');
+
+    // Carregar sessão novamente para garantir persistência
+    const s2 = await getOrCreateSession('wa', FROM);
+    const st = (s2 as any).state || {};
+    expect(st.dados_coletados?.equipamento).toBe('fogão elétrico');
+    expect(!!st.orcamento_entregue).toBe(false);
+    expect(st.pendingEquipmentSwitch).toBeFalsy();
+  });
+
+  it('quando pending existe e usuário nega (não), mantém equipamento e limpa pending', async () => {
+    await setSessionState(session.id, { ...(session.state||{}),
+      dados_coletados: { equipamento: 'fogão a gás' },
+      orcamento_entregue: true,
+      pendingEquipmentSwitch: 'fogão de indução'
+    });
+
+    const out = await orchestrateInbound(FROM, 'não, manter', session);
+    const text = typeof out === 'string' ? out : (out as any)?.text || '';
+    expect(text.toLowerCase()).toContain('mantemos fogão a gás');
+
+    const s2 = await getOrCreateSession('wa', FROM);
+    const st = (s2 as any).state || {};
+    expect(st.dados_coletados?.equipamento).toBe('fogão a gás');
+    expect(!!st.orcamento_entregue).toBe(true);
+    expect(st.pendingEquipmentSwitch).toBeFalsy();
+  });
+});
+

--- a/webhook-ai/test/pending-switch.spec.ts
+++ b/webhook-ai/test/pending-switch.spec.ts
@@ -12,10 +12,11 @@ describe('Confirmação de troca de equipamento (pendingEquipmentSwitch)', () =>
   });
 
   it('quando pending existe e usuário confirma (sim), troca equipamento e reseta orçamento', async () => {
-    await setSessionState(session.id, { ...(session.state||{}),
+    await setSessionState(session.id, {
+      ...(session.state || {}),
       dados_coletados: { equipamento: 'fogão a gás', marca: 'Brastemp', problema: 'não acende' },
       orcamento_entregue: true,
-      pendingEquipmentSwitch: 'fogão elétrico'
+      pendingEquipmentSwitch: 'fogão elétrico',
     });
 
     const out = await orchestrateInbound(FROM, 'sim, pode trocar', session);
@@ -31,10 +32,11 @@ describe('Confirmação de troca de equipamento (pendingEquipmentSwitch)', () =>
   });
 
   it('quando pending existe e usuário nega (não), mantém equipamento e limpa pending', async () => {
-    await setSessionState(session.id, { ...(session.state||{}),
+    await setSessionState(session.id, {
+      ...(session.state || {}),
       dados_coletados: { equipamento: 'fogão a gás' },
       orcamento_entregue: true,
-      pendingEquipmentSwitch: 'fogão de indução'
+      pendingEquipmentSwitch: 'fogão de indução',
     });
 
     const out = await orchestrateInbound(FROM, 'não, manter', session);
@@ -48,4 +50,3 @@ describe('Confirmação de troca de equipamento (pendingEquipmentSwitch)', () =>
     expect(st.pendingEquipmentSwitch).toBeFalsy();
   });
 });
-

--- a/webhook-ai/test/scheduling.spec.ts
+++ b/webhook-ai/test/scheduling.spec.ts
@@ -28,8 +28,23 @@ describe('Fluxo orçamento -> agendamento', () => {
     // Evitar perguntas adicionais no meio do fluxo durante testes determinísticos
     process.env.NODE_ENV = 'test';
     // Prencher contexto mínimo e forçar decisão de gerar orçamento via LLM_FAKE_JSON
-    await setSessionState(session.id, { ...(session.state||{}), dados_coletados: { equipamento: 'fogão a gás', marca: 'Brastemp', problema: 'não funciona 2 bocas' } });
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'orcamento_equipamento', acao_principal:'gerar_orcamento', dados_extrair:{ equipamento: 'fogão a gás', marca: 'Brastemp', problema: 'não funciona 2 bocas' } });
+    await setSessionState(session.id, {
+      ...(session.state || {}),
+      dados_coletados: {
+        equipamento: 'fogão a gás',
+        marca: 'Brastemp',
+        problema: 'não funciona 2 bocas',
+      },
+    });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'orcamento_equipamento',
+      acao_principal: 'gerar_orcamento',
+      dados_extrair: {
+        equipamento: 'fogão a gás',
+        marca: 'Brastemp',
+        problema: 'não funciona 2 bocas',
+      },
+    });
 
     const out1 = await orchestrateInbound(FROM, 'não funciona 2 bocas', session);
     expect(typeof out1).toBe('string');
@@ -40,9 +55,13 @@ describe('Fluxo orçamento -> agendamento', () => {
     expect(!!st.orcamento_entregue).toBe(true);
 
     // Agora, com orçamento entregue, a fala de agendar deve retornar um texto de follow-up (sem exigir que chame middleware)
-    process.env.LLM_FAKE_JSON = JSON.stringify({ intent:'agendamento_servico', acao_principal:'agendar_servico', dados_extrair:{ equipamento: 'fogão a gás' }, resposta_sugerida: 'Vamos agendar' });
+    process.env.LLM_FAKE_JSON = JSON.stringify({
+      intent: 'agendamento_servico',
+      acao_principal: 'agendar_servico',
+      dados_extrair: { equipamento: 'fogão a gás' },
+      resposta_sugerida: 'Vamos agendar',
+    });
     const out2 = await orchestrateInbound(FROM, 'quero agendar amanhã 9h', session);
     expect(typeof out2).toBe('string');
   });
 });
-

--- a/webhook-ai/test/setup.ts
+++ b/webhook-ai/test/setup.ts
@@ -4,4 +4,3 @@ process.env.API_URL = 'http://127.0.0.1:65535';
 process.env.MIDDLEWARE_URL = 'http://127.0.0.1:65535';
 // Clear LLM_FAKE_JSON by default; tests set it as needed
 delete process.env.LLM_FAKE_JSON;
-


### PR DESCRIPTION
This PR adds robust CI and developer tooling for the webhook-ai package, plus extra tests and docs polish.

What’s included:
- CI: New GitHub Actions workflow (.github/workflows/webhook-ai-ci.yml)
  - Node 18, npm ci, cache
  - Lint, build, test with coverage
  - Deterministic flags set: NODE_ENV=test, MOCK_SUPABASE=true, QUOTE_OFFLINE_FALLBACK=true
  - Coverage artifact upload
- Tooling: ESLint (flat config) + Prettier added to webhook-ai, wired scripts (lint/format). Lint passes and code formatted
- Tests: pending-switch.spec.ts covering pendingEquipmentSwitch confirmation (SIM/NÃO). Local run: 4 files, 12 tests passing
- Docs: CI status badge added to README

Why:
- Ensure reproducible, flake-free CI for webhook-ai and protect against regressions
- Improve dev ergonomics and consistency via lint/format

Local validation:
- npm --prefix webhook-ai run lint → OK
- npm --prefix webhook-ai run build → OK
- npm --prefix webhook-ai run test → OK (12/12)

After merge:
- Every change in webhook-ai or the workflow will trigger lint/build/test automatically

Thanks!

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author