### PR TITLE
Fix WhatsApp connect routes: add GET endpoint and background processing

### DIFF
--- a/webhook-ai/src/routes/whatsapp.ts
+++ b/webhook-ai/src/routes/whatsapp.ts
@@ -46,10 +46,19 @@ whatsappRouter.post('/logout', async (_req, res) => {
   res.json({ ok: true });
 });
 
+// GET version for easy browser testing
+whatsappRouter.get('/connect', async (req, res) => {
+  const force = String(req.query.force || '').toLowerCase() === 'true';
+  res.status(202).json({ ok: true, force, started: true });
+  // Start connection in background to avoid timeout
+  setTimeout(() => waClient.connect(force).catch(e => console.error('[WA] connect error', e)), 0);
+});
+
 whatsappRouter.post('/connect', async (req, res) => {
   const force = String(req.query.force || '').toLowerCase() === 'true';
-  await waClient.connect(force);
-  res.json({ ok: true, force });
+  res.status(202).json({ ok: true, force, started: true });
+  // Start connection in background to avoid timeout
+  setTimeout(() => waClient.connect(force).catch(e => console.error('[WA] connect error', e)), 0);
 });
 
 // Debug: enviar texto manualmente


### PR DESCRIPTION
## Fixes WhatsApp connect route issues

- Add GET /whatsapp/connect for easy browser testing
- Return 202 immediately and process connection in background
- Prevents 502 timeouts during WhatsApp initialization
- Both GET and POST now use same background processing pattern

This resolves the "Cannot GET /whatsapp/connect" error and prevents 502 timeouts when initializing WhatsApp client.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author