### PR TITLE
Fix Chromium path detection in Railway nixpacks

### DIFF
--- a/webhook-ai/nixpacks.toml
+++ b/webhook-ai/nixpacks.toml
@@ -8,8 +8,9 @@ nixPkgs = ["nodejs_18", "chromium", "nss", "freetype", "harfbuzz", "ca-certifica
 cmds = [
   "npm ci",
   "mkdir -p /usr/bin /app/.cache",
-  "ln -sf $(which chromium) /usr/bin/chromium",
-  "chmod +x /usr/bin/chromium"
+  "find /nix/store -name chromium -type f -executable 2>/dev/null | head -1 | xargs -I {} ln -sf {} /usr/bin/chromium || echo 'Chromium not found in /nix/store'",
+  "ls -la /usr/bin/chromium || echo 'Symlink not created'",
+  "chmod +x /usr/bin/chromium 2>/dev/null || echo 'Could not chmod chromium'"
 ]
 
 [phases.build]


### PR DESCRIPTION
## Fixes Chromium path detection in Railway deployment

- Use find command to locate chromium in /nix/store instead of which
- Add debugging output to troubleshoot symlink creation
- More robust error handling for chmod operations
- This should resolve the persistent 'spawn /usr/bin/chromium ENOENT' error

The previous approach using `which chromium` was failing because the command wasn't finding chromium during the install phase. This new approach directly searches the Nix store for the chromium binary and creates the symlink.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author